### PR TITLE
add HDF5Reader and non-SAR integration reference

### DIFF
--- a/grdl/IO/README.md
+++ b/grdl/IO/README.md
@@ -13,6 +13,7 @@ The IO module provides a unified interface for reading and writing various geosp
 | Format | Reader Class | Backend | Status |
 |--------|-------------|---------|--------|
 | GeoTIFF/COG | `GeoTIFFReader` | rasterio | ✅ Implemented |
+| HDF5/HDF-EOS5 | `HDF5Reader` | h5py | ✅ Implemented |
 | NITF | `NITFReader` | rasterio/GDAL | ✅ Implemented |
 
 ### SAR (Synthetic Aperture Radar) — `sar/` submodule
@@ -122,6 +123,27 @@ with CPHDReader('cphd_data.cphd') as reader:
 
     # Read phase history data
     ph_data = reader.read_full(bands=[0])  # First channel
+```
+
+#### HDF5 - NASA, JAXA, Hyperspectral Products
+
+```python
+from grdl.IO import HDF5Reader
+
+# Browse datasets in an HDF5 file
+datasets = HDF5Reader.list_datasets('MOD09GA.h5')
+for path, shape, dtype in datasets:
+    print(f"{path}: {shape} ({dtype})")
+
+# Open with explicit dataset path
+with HDF5Reader('MOD09GA.h5', dataset_path='/MODIS_Grid/sur_refl_b01') as reader:
+    print(f"Shape: {reader.get_shape()}")
+    chip = reader.read_chip(0, 512, 0, 512)
+
+# Auto-detect first suitable dataset
+with HDF5Reader('product.h5') as reader:
+    print(f"Selected: {reader.dataset_path}")
+    full = reader.read_full()
 ```
 
 #### GeoTIFF - Any Raster Imagery (SAR GRD, EO, MSI)

--- a/grdl/IO/TODO.md
+++ b/grdl/IO/TODO.md
@@ -19,8 +19,9 @@ Roadmap and planned features for the IO module.
   - [x] `open_sar()` - Auto-detection utility
 - [x] Base format readers (IO level)
   - [x] `GeoTIFFReader` - GeoTIFF/COG via rasterio
+  - [x] `HDF5Reader` - HDF5/HDF-EOS5 via h5py (auto-detect or explicit dataset path)
   - [x] `NITFReader` - Generic NITF via rasterio/GDAL
-  - [x] `open_image()` - Auto-detection for base formats
+  - [x] `open_image()` - Auto-detection for base formats (GeoTIFF, HDF5, NITF)
 - [x] BIOMASS readers (`sar/biomass.py`)
   - [x] `BIOMASSL1Reader` - BIOMASS L1 SCS format (magnitude/phase GeoTIFFs)
   - [x] `open_biomass()` - Auto-detection utility
@@ -107,6 +108,7 @@ Roadmap and planned features for the IO module.
   - [x] ImageJ/Fiji ports tests (124 tests across 12 components)
   - [x] IO import path tests (`test_io_imports.py`)
   - [x] GeoTIFF reader tests (`test_io_geotiff.py`)
+  - [x] HDF5 reader tests (`test_io_hdf5.py`)
   - [x] NITF reader tests (`test_io_nitf.py`)
   - [x] SAR backend detection tests (`test_io_sar_backend.py`)
   - [x] SAR reader API contract tests (`test_io_sar_readers.py`)
@@ -127,18 +129,14 @@ Roadmap and planned features for the IO module.
 ### Base Format Readers (IO level)
 
 - [x] **GeoTIFFReader** - General raster imagery via rasterio
+- [x] **HDF5Reader** - HDF5/HDF-EOS5 via h5py (auto-detect or explicit dataset path)
 - [x] **NITFReader** - Generic NITF via rasterio/GDAL
-- [x] **open_image()** - Auto-detect GeoTIFF or NITF
+- [x] **open_image()** - Auto-detect GeoTIFF, HDF5, or NITF
 
 - [ ] **JP2Reader** - JPEG2000 imagery
   - Via rasterio or glymur
   - Common in satellite imagery (Sentinel-2)
   - Handle tiled/pyramidal structure
-
-- [ ] **HDF5Reader** - HDF5/NetCDF formats
-  - Use h5py or xarray
-  - Common in climate/weather data
-  - Handle multi-dimensional arrays
 
 ### Geospatial Readers (geospatial.py) - NEW MODULE
 

--- a/grdl/IO/__init__.py
+++ b/grdl/IO/__init__.py
@@ -3,12 +3,13 @@
 IO Module - Input/Output Operations for Geospatial Imagery.
 
 Handles reading and writing various geospatial data formats. Base data
-format readers (GeoTIFF, NITF) live at this level.  Modality-specific
+format readers (GeoTIFF, NITF, HDF5) live at this level.  Modality-specific
 readers are organized into submodules (``sar/``).
 
 Dependencies
 ------------
 rasterio
+h5py
 sarkit (primary) or sarpy (fallback)
 requests
 
@@ -29,7 +30,7 @@ Created
 
 Modified
 --------
-2026-02-09
+2026-02-10
 """
 
 # Standard library
@@ -41,6 +42,7 @@ from grdl.IO.base import ImageReader, ImageWriter, CatalogInterface
 
 # Base format readers (IO level)
 from grdl.IO.geotiff import GeoTIFFReader
+from grdl.IO.hdf5 import HDF5Reader
 from grdl.IO.nitf import NITFReader
 
 # SAR submodule
@@ -101,6 +103,13 @@ def open_image(filepath: Union[str, Path]) -> ImageReader:
         except (ValueError, ImportError):
             pass
 
+    # Try HDF5
+    if filepath.suffix.lower() in ('.h5', '.he5', '.hdf5', '.hdf'):
+        try:
+            return HDF5Reader(filepath)
+        except (ValueError, ImportError):
+            pass
+
     # Try GeoTIFF as fallback for unknown extensions
     try:
         return GeoTIFFReader(filepath)
@@ -109,7 +118,8 @@ def open_image(filepath: Union[str, Path]) -> ImageReader:
 
     raise ValueError(
         f"Could not open {filepath}. "
-        "Ensure file is a valid GeoTIFF or NITF and rasterio is installed. "
+        "Ensure file is a valid GeoTIFF, NITF, or HDF5 and the required "
+        "library (rasterio, h5py) is installed. "
         "For SAR-specific formats (SICD, CPHD, CRSD), use open_sar()."
     )
 
@@ -121,6 +131,7 @@ __all__ = [
     'CatalogInterface',
     # Base format readers
     'GeoTIFFReader',
+    'HDF5Reader',
     'NITFReader',
     # SAR readers
     'SICDReader',

--- a/grdl/IO/hdf5.py
+++ b/grdl/IO/hdf5.py
@@ -1,0 +1,456 @@
+# -*- coding: utf-8 -*-
+"""
+HDF5 Reader - Read HDF5 and HDF-EOS5 imagery.
+
+Base data format reader for HDF5 files regardless of producer
+(NASA, ASI, JAXA, etc.). Supports explicit dataset path selection
+or auto-detection of the first suitable numeric array. Lives at the
+IO level so modality submodules can use it without cross-submodule
+dependencies.
+
+Dependencies
+------------
+h5py
+
+Author
+------
+Duane Smalley, PhD
+duane.d.smalley@gmail.com
+
+License
+-------
+MIT License
+Copyright (c) 2024 geoint.org
+See LICENSE file for full text.
+
+Created
+-------
+2026-02-10
+
+Modified
+--------
+2026-02-10
+"""
+
+# Standard library
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+# Third-party
+import numpy as np
+
+try:
+    import h5py
+    _HAS_H5PY = True
+except ImportError:
+    _HAS_H5PY = False
+
+# GRDL internal
+from grdl.IO.base import ImageReader
+
+
+def _find_datasets(
+    group: "h5py.Group",
+    min_ndim: int = 2,
+) -> List[Tuple[str, Tuple[int, ...], str]]:
+    """Walk an HDF5 group and collect numeric datasets.
+
+    Parameters
+    ----------
+    group : h5py.Group
+        Root group or subgroup to search.
+    min_ndim : int
+        Minimum number of dimensions to include. Default is 2.
+
+    Returns
+    -------
+    List[Tuple[str, Tuple[int, ...], str]]
+        List of ``(path, shape, dtype)`` for each matching dataset.
+    """
+    results: List[Tuple[str, Tuple[int, ...], str]] = []
+
+    def _visitor(name: str, obj: Any) -> None:
+        if isinstance(obj, h5py.Dataset):
+            if obj.ndim >= min_ndim and np.issubdtype(obj.dtype, np.number):
+                results.append((f"/{name}", obj.shape, str(obj.dtype)))
+
+    group.visititems(_visitor)
+    return results
+
+
+class HDF5Reader(ImageReader):
+    """Read HDF5 and HDF-EOS5 imagery.
+
+    Reads any HDF5 file containing 2D or 3D numeric arrays, including
+    NASA Earthdata products (MODIS, VIIRS, ASTER, ICESat-2, GEDI,
+    EMIT), ASI PRISMA, and JAXA missions. Uses h5py as the backend.
+
+    The reader targets a single dataset within the HDF5 hierarchy.
+    Provide ``dataset_path`` to select a specific dataset, or omit it
+    to auto-detect the first 2D+ numeric array.
+
+    Parameters
+    ----------
+    filepath : str or Path
+        Path to the HDF5 file (.h5, .he5, .hdf5).
+    dataset_path : str, optional
+        Internal HDF5 path to the target dataset
+        (e.g., ``'/HDFEOS/GRIDS/VNP_Grid_16Day/Data Fields/NDVI'``).
+        If None, auto-detects the first suitable dataset.
+
+    Attributes
+    ----------
+    filepath : Path
+        Path to the HDF5 file.
+    metadata : Dict[str, Any]
+        Standardized metadata dictionary.
+    dataset_path : str
+        Resolved internal path to the active dataset.
+
+    Raises
+    ------
+    ImportError
+        If h5py is not installed.
+    FileNotFoundError
+        If the file does not exist.
+    ValueError
+        If no suitable dataset is found or ``dataset_path`` is invalid.
+
+    Examples
+    --------
+    >>> from grdl.IO.hdf5 import HDF5Reader
+    >>> with HDF5Reader('MOD09GA.h5', dataset_path='/MODIS_Grid/sur_refl_b01') as reader:
+    ...     chip = reader.read_chip(0, 512, 0, 512)
+    ...     print(reader.metadata['format'])
+    'HDF5'
+
+    >>> # Auto-detect first dataset
+    >>> with HDF5Reader('product.h5') as reader:
+    ...     print(reader.dataset_path)
+    ...     print(reader.get_shape())
+
+    >>> # Browse available datasets
+    >>> datasets = HDF5Reader.list_datasets('product.h5')
+    >>> for path, shape, dtype in datasets:
+    ...     print(f"{path}: {shape} ({dtype})")
+    """
+
+    def __init__(
+        self,
+        filepath: Union[str, Path],
+        dataset_path: Optional[str] = None,
+    ) -> None:
+        if not _HAS_H5PY:
+            raise ImportError(
+                "h5py is required for HDF5 reading. "
+                "Install with: pip install h5py"
+            )
+        self._requested_path = dataset_path
+        super().__init__(filepath)
+
+    def _load_metadata(self) -> None:
+        """Open the HDF5 file and load metadata for the target dataset."""
+        try:
+            self._file = h5py.File(str(self.filepath), "r")
+        except Exception as e:
+            raise ValueError(
+                f"Failed to open HDF5 file: {self.filepath}: {e}"
+            ) from e
+
+        # Resolve dataset path
+        if self._requested_path is not None:
+            if self._requested_path not in self._file:
+                available = _find_datasets(self._file)
+                paths = [p for p, _, _ in available]
+                self._file.close()
+                raise ValueError(
+                    f"Dataset path '{self._requested_path}' not found in "
+                    f"{self.filepath}. Available datasets: {paths}"
+                )
+            obj = self._file[self._requested_path]
+            if not isinstance(obj, h5py.Dataset):
+                self._file.close()
+                raise ValueError(
+                    f"Path '{self._requested_path}' is a group, not a dataset."
+                )
+            self.dataset_path = self._requested_path
+        else:
+            # Auto-detect first suitable numeric dataset (>= 2D)
+            candidates = _find_datasets(self._file, min_ndim=2)
+            if not candidates:
+                self._file.close()
+                raise ValueError(
+                    f"No 2D+ numeric datasets found in {self.filepath}. "
+                    "Provide an explicit dataset_path."
+                )
+            self.dataset_path = candidates[0][0]
+
+        ds = self._file[self.dataset_path]
+        ndim = ds.ndim
+
+        if ndim == 2:
+            rows, cols = ds.shape
+            bands = 1
+        elif ndim == 3:
+            bands, rows, cols = ds.shape
+        else:
+            self._file.close()
+            raise ValueError(
+                f"Dataset '{self.dataset_path}' has {ndim} dimensions. "
+                "Only 2D and 3D datasets are supported."
+            )
+
+        # Collect HDF5 attributes as extras
+        extras: Dict[str, Any] = {
+            'dataset_path': self.dataset_path,
+        }
+        for key, val in ds.attrs.items():
+            try:
+                if isinstance(val, bytes):
+                    extras[key] = val.decode("utf-8", errors="replace")
+                elif isinstance(val, np.ndarray):
+                    extras[key] = val.tolist()
+                elif isinstance(val, (np.integer, np.floating)):
+                    extras[key] = val.item()
+                else:
+                    extras[key] = val
+            except Exception:
+                pass
+
+        # Root-level attributes (file-level metadata)
+        for key, val in self._file.attrs.items():
+            extra_key = f"file_{key}"
+            try:
+                if isinstance(val, bytes):
+                    extras[extra_key] = val.decode("utf-8", errors="replace")
+                elif isinstance(val, np.ndarray):
+                    extras[extra_key] = val.tolist()
+                elif isinstance(val, (np.integer, np.floating)):
+                    extras[extra_key] = val.item()
+                else:
+                    extras[extra_key] = val
+            except Exception:
+                pass
+
+        self.metadata = {
+            'format': 'HDF5',
+            'rows': rows,
+            'cols': cols,
+            'bands': bands,
+            'dtype': str(ds.dtype),
+            **extras,
+        }
+
+    def read_chip(
+        self,
+        row_start: int,
+        row_end: int,
+        col_start: int,
+        col_end: int,
+        bands: Optional[List[int]] = None,
+    ) -> np.ndarray:
+        """Read a spatial chip from the HDF5 dataset.
+
+        Uses HDF5 hyperslab selection for efficient partial reads
+        without loading the full dataset into memory.
+
+        Parameters
+        ----------
+        row_start : int
+            Starting row index (inclusive).
+        row_end : int
+            Ending row index (exclusive).
+        col_start : int
+            Starting column index (inclusive).
+        col_end : int
+            Ending column index (exclusive).
+        bands : Optional[List[int]]
+            Band indices to read (0-based). If None, read all bands.
+            Only applicable to 3D datasets.
+
+        Returns
+        -------
+        np.ndarray
+            Image chip with shape ``(rows, cols)`` for single band or
+            ``(bands, rows, cols)`` for multi-band.
+
+        Raises
+        ------
+        ValueError
+            If indices are out of bounds.
+        """
+        if row_start < 0 or col_start < 0:
+            raise ValueError("Start indices must be non-negative")
+        if row_end > self.metadata['rows'] or col_end > self.metadata['cols']:
+            raise ValueError("End indices exceed image dimensions")
+
+        ds = self._file[self.dataset_path]
+
+        if ds.ndim == 2:
+            return ds[row_start:row_end, col_start:col_end]
+
+        # 3D: shape is (bands, rows, cols)
+        if bands is None:
+            data = ds[:, row_start:row_end, col_start:col_end]
+        else:
+            data = ds[bands, row_start:row_end, col_start:col_end]
+
+        if data.shape[0] == 1:
+            return data[0]
+        return data
+
+    def read_full(self, bands: Optional[List[int]] = None) -> np.ndarray:
+        """Read the entire dataset.
+
+        Parameters
+        ----------
+        bands : Optional[List[int]]
+            Band indices to read (0-based). If None, read all bands.
+
+        Returns
+        -------
+        np.ndarray
+            Full dataset.
+        """
+        ds = self._file[self.dataset_path]
+
+        if ds.ndim == 2:
+            return ds[()]
+
+        if bands is None:
+            data = ds[()]
+        else:
+            data = ds[bands]
+
+        if data.shape[0] == 1:
+            return data[0]
+        return data
+
+    def get_shape(self) -> Tuple[int, ...]:
+        """Get image dimensions.
+
+        Returns
+        -------
+        Tuple[int, ...]
+            ``(rows, cols)`` for single band or
+            ``(rows, cols, bands)`` for multi-band.
+        """
+        if self.metadata['bands'] == 1:
+            return (self.metadata['rows'], self.metadata['cols'])
+        return (
+            self.metadata['rows'],
+            self.metadata['cols'],
+            self.metadata['bands'],
+        )
+
+    def get_dtype(self) -> np.dtype:
+        """Get the data type of the dataset.
+
+        Returns
+        -------
+        np.dtype
+        """
+        return np.dtype(self.metadata['dtype'])
+
+    def get_geolocation(self) -> Optional[Dict[str, Any]]:
+        """Get geolocation information from HDF5 attributes.
+
+        Attempts to extract CRS and spatial extent from dataset or
+        file-level attributes. Returns None if no geolocation
+        metadata is found.
+
+        Returns
+        -------
+        Optional[Dict[str, Any]]
+            Geolocation dict if available, else None.
+        """
+        geo: Dict[str, Any] = {}
+
+        # Common HDF-EOS / CF attribute names for CRS
+        for key in ('crs', 'spatial_ref', 'Projection', 'file_crs',
+                     'file_spatial_ref'):
+            if key in self.metadata:
+                geo['crs'] = self.metadata[key]
+                break
+
+        # Common attribute names for bounds
+        for key in ('bounds', 'geospatial_bounds', 'file_geospatial_bounds'):
+            if key in self.metadata:
+                geo['bounds'] = self.metadata[key]
+                break
+
+        # Lat/lon extent attributes (NASA Earthdata convention)
+        lat_keys = ('geospatial_lat_min', 'file_geospatial_lat_min',
+                     'SouthBoundingCoordinate')
+        lon_keys = ('geospatial_lon_min', 'file_geospatial_lon_min',
+                     'WestBoundingCoordinate')
+        for lat_key in lat_keys:
+            if lat_key in self.metadata:
+                prefix = lat_key.rsplit('min', 1)[0] if 'min' in lat_key else ''
+                max_lat_key = f"{prefix}max" if prefix else lat_key.replace(
+                    'South', 'North')
+                geo.setdefault('lat_min', self.metadata.get(lat_key))
+                geo.setdefault('lat_max', self.metadata.get(max_lat_key))
+                break
+        for lon_key in lon_keys:
+            if lon_key in self.metadata:
+                prefix = lon_key.rsplit('min', 1)[0] if 'min' in lon_key else ''
+                max_lon_key = f"{prefix}max" if prefix else lon_key.replace(
+                    'West', 'East')
+                geo.setdefault('lon_min', self.metadata.get(lon_key))
+                geo.setdefault('lon_max', self.metadata.get(max_lon_key))
+                break
+
+        return geo if geo else None
+
+    def close(self) -> None:
+        """Close the HDF5 file handle."""
+        if hasattr(self, '_file') and self._file is not None:
+            self._file.close()
+            self._file = None
+
+    @staticmethod
+    def list_datasets(
+        filepath: Union[str, Path],
+        min_ndim: int = 2,
+    ) -> List[Tuple[str, Tuple[int, ...], str]]:
+        """List numeric datasets in an HDF5 file.
+
+        Utility method for exploring an HDF5 file's contents without
+        opening a full reader instance.
+
+        Parameters
+        ----------
+        filepath : str or Path
+            Path to the HDF5 file.
+        min_ndim : int
+            Minimum number of dimensions. Default is 2.
+
+        Returns
+        -------
+        List[Tuple[str, Tuple[int, ...], str]]
+            List of ``(path, shape, dtype)`` tuples.
+
+        Raises
+        ------
+        ImportError
+            If h5py is not installed.
+
+        Examples
+        --------
+        >>> datasets = HDF5Reader.list_datasets('product.h5')
+        >>> for path, shape, dtype in datasets:
+        ...     print(f"{path}: {shape} ({dtype})")
+        /HDFEOS/GRIDS/NDVI: (2400, 2400) float32
+        """
+        if not _HAS_H5PY:
+            raise ImportError(
+                "h5py is required for HDF5 reading. "
+                "Install with: pip install h5py"
+            )
+        filepath = Path(filepath)
+        if not filepath.exists():
+            raise FileNotFoundError(f"File not found: {filepath}")
+
+        with h5py.File(str(filepath), "r") as f:
+            return _find_datasets(f, min_ndim=min_ndim)

--- a/grdl/IO/integration.md
+++ b/grdl/IO/integration.md
@@ -1,0 +1,243 @@
+# Non-SAR Remote Sensing Platform Integration Guide
+
+Reference of open and commercially accessible remote sensing platforms, organized by modality. Covers platforms, download portals, file formats, and GRDL reader implementation priorities.
+
+## Electro-Optical Multispectral
+
+### Tier 1: Fully Open / Free
+
+| Platform | Agency | Resolution | Bands | Revisit | Format | Status |
+|----------|--------|-----------|-------|---------|--------|--------|
+| Landsat 8/9 | USGS/NASA | 15 m PAN, 30 m MS, 100 m TIR | 11 (0.43-12.51 um) | 8 days combined | COG/GeoTIFF | Active |
+| Sentinel-2A/B/C | ESA/Copernicus | 10/20/60 m | 13 (443-2190 nm) | 5 days | JP2 (SAFE), COG on AWS | Active |
+| MODIS (Terra/Aqua) | NASA | 250/500/1000 m | 36 (0.4-14.4 um) | 1-2 days | HDF4 (HDF-EOS) | Active (EOL ~2026-27) |
+| VIIRS (NPP, NOAA-20/21) | NASA/NOAA | 375/750 m | 22 (0.41-12.5 um) | ~12 hrs | HDF5, NetCDF | Active |
+| ASTER (Terra) | NASA/METI | 15/30/90 m | 14 (9 functional) | 16 days | HDF-EOS (HDF4) | Active (limited) |
+| HLS | NASA GSFC | 30 m | 11-13 | 2-3 days | COG | Active |
+| NAIP | USDA | 30-60 cm | 3-4 (RGB/RGBN) | 2-3 yr cycle | GeoTIFF, JP2 | Active (aerial) |
+| Maxar Open Data | Maxar/Vantor | 30-50 cm | 3-4 (RGB/RGBN) | Event-based | COG | Active (CC 4.0) |
+| CBERS-4/4A | INPE/CAST | 2-55 m | 4+PAN | 5-26 days | GeoTIFF | Active |
+| VENuS | CNES/ISA | 5.3 m | 12 (420-910 nm) | 2 days (selected sites) | COG | Decommissioned (archive) |
+
+**Landsat 8/9** -- Workhorse of civilian EO. Collection 2 delivered as COG. Download: [USGS EarthExplorer](https://earthexplorer.usgs.gov), [Landsat on AWS](https://registry.opendata.aws/landsat-8/).
+
+**Sentinel-2** -- Highest-resolution free global multispectral. Native format is SAFE directory with JP2 imagery; COG available on AWS via Element 84. Sentinel-2C launched Sep 2024, replaced 2A operationally Jan 2025. Download: [Copernicus Data Space](https://dataspace.copernicus.eu), [Sentinel-2 on AWS](https://registry.opendata.aws/sentinel-2/).
+
+**MODIS** -- 20+ year archive, near-daily global. Aqua science data expected to end ~Aug 2026; Terra ~Jan 2027. Transitioning to VIIRS. Download: [LAADS DAAC](https://ladsweb.modaps.eosdis.nasa.gov), [NASA Earthdata](https://earthdata.nasa.gov).
+
+**VIIRS** -- MODIS successor. Three active satellites (NPP, NOAA-20, NOAA-21). Download: [LAADS DAAC](https://ladsweb.modaps.eosdis.nasa.gov), [NOAA CLASS](https://www.avl.class.noaa.gov).
+
+**ASTER** -- SWIR detector failed Apr 2008; VNIR stopped Apr 2023; TIR still active. On-demand L2/L3 processing decommissioned Dec 2025. Archive remains. Download: [USGS EarthExplorer](https://earthexplorer.usgs.gov), [LP DAAC](https://lpdaac.usgs.gov).
+
+**HLS** -- Harmonized Landsat-Sentinel product. Radiometrically cross-calibrated, gridded on Sentinel-2 MGRS tiles. Download: [NASA Earthdata](https://search.earthdata.nasa.gov), [Planetary Computer](https://planetarycomputer.microsoft.com/dataset/group/hls).
+
+**NAIP** -- US-only aerial imagery, 30-60 cm. Not a satellite. Download: [USGS EarthExplorer](https://earthexplorer.usgs.gov), [National Map](https://apps.nationalmap.gov/downloader/), [NAIP Hub](https://naip-usdaonline.hub.arcgis.com/).
+
+**Maxar Open Data** -- VHR imagery released under CC 4.0 for disaster response events. STAC catalog on AWS. Download: [Maxar Open Data on AWS](https://registry.opendata.aws/maxar-open-data/).
+
+**CBERS-4/4A** -- Brazil-China program, fully open. Download: [INPE Catalog](http://www.dgi.inpe.br/catalogo/explore), [CBERS on AWS](https://registry.opendata.aws/cbers/).
+
+**VENuS** -- 12 narrow VNIR bands at 5.3 m, decommissioned Aug 2024. Archive on AWS. Download: [VENuS on AWS](https://registry.opendata.aws/venus-l2a-cogs/).
+
+### Tier 2: Commercial with Free Access Pathways
+
+| Platform | Agency | Resolution | Bands | Revisit | Format | Free Access |
+|----------|--------|-----------|-------|---------|--------|-------------|
+| PlanetScope | Planet Labs | 3 m | 4-8 | Daily | GeoTIFF | NICFI, NASA CSDA, ESA Earthnet |
+| SkySat | Planet Labs | 50 cm | 4+PAN | 12x/day | GeoTIFF | ESA Earthnet, NASA CSDA |
+| WorldView-2/3 | Maxar/Vantor | 31-46 cm PAN, 1.2-1.8 m MS | 8-29 | <1 day | NITF, GeoTIFF | NASA CSDA, ESA TPM |
+| WorldView Legion | Maxar/Vantor | 34 cm PAN, 1.36 m MS | 8+PAN | 15x/day | NITF, GeoTIFF | NASA CSDA, ESA TPM |
+| Pleiades 1A/1B | CNES/Airbus | 50 cm PAN, 2 m MS | 4+PAN | Daily | DIMAP (GeoTIFF+XML), JP2 | ESA TPM, Dinamis |
+| Pleiades Neo | Airbus | 30 cm PAN, 1.2 m MS | 6+PAN | 2x/day | DIMAP (GeoTIFF+XML) | ESA TPM |
+| SPOT 6 | Airbus | 1.5 m PAN, 6 m MS | 4+PAN | Daily | DIMAP (GeoTIFF+XML) | ESA TPM, Dinamis |
+| Gaofen (16m WFV) | CNSA/CRESDA | 16 m (WFV open) | 4-8 | 2 days | TIFF+XML | 16m WFV open via CNSA-GEO |
+| SuperView-1 | Siwei (China) | 50 cm PAN, 2 m MS | 4+PAN | ~1 day | GeoTIFF | Preview only |
+| Jilin-1 | Chang Guang | 30 cm-1.2 m | 4+PAN | Multi-daily | GeoTIFF | None (commercial) |
+
+**Free access programs:**
+- [NASA CSDA](https://www.earthdata.nasa.gov/about/csda) -- US government researchers; covers Planet and Maxar
+- [ESA Third Party Missions](https://earth.esa.int/eogateway/missions) -- European researchers, proposal-based
+- [Planet NICFI](https://www.planet.com/nicfi/) -- Tropical forest monitoring, open access
+- [Dinamis](https://dinamis.data-terra.org/) -- French institutional users, SPOT/Pleiades
+
+### Planned
+
+| Platform | Agency | Resolution | Bands | Launch | Notes |
+|----------|--------|-----------|-------|--------|-------|
+| Landsat Next | NASA/USGS | ~10-15 m | 26 | 2030-31 | 3-satellite constellation, 6-day revisit |
+
+---
+
+## Hyperspectral
+
+| Platform | Agency | Spectral Range | Bands | Resolution | Format | Download | Status |
+|----------|--------|---------------|-------|-----------|--------|----------|--------|
+| PRISMA | ASI (Italy) | 400-2500 nm | 239+PAN | 30 m (5 m PAN) | HDF5 (.he5) | [prisma.asi.it](https://prisma.asi.it) | Active (EOL ~2026) |
+| EnMAP | DLR/GFZ | 420-2450 nm | 228 | 30 m | GeoTIFF, COG, JP2, ENVI | [EOWEB](https://eoweb.dlr.de), [EOC Geoservice](https://geoservice.dlr.de/web/datasets/enmap) | Active (EOL Sep 2026) |
+| EMIT | NASA/JPL (ISS) | 381-2493 nm | 285 | 60 m | NetCDF4 | [NASA Earthdata](https://search.earthdata.nasa.gov) | Active |
+| DESIS | DLR/Teledyne (ISS) | 400-1000 nm | 235 | 30 m | COG | [Teledyne TCloud](https://teledyne.tcloudhost.com), [DLR Geoservice](https://geoservice.dlr.de/data-assets/hxom21uqeo90.html) | End-of-life ~2025 (archive) |
+| HISUI | JAXA/METI (ISS) | 400-2500 nm | 185 | 20x31 m | HDF5 | [Tellus](https://www.tellusxdp.com/en-us/catalog/data/hisui.html) | Active |
+| Hyperion (EO-1) | NASA/USGS | 357-2576 nm | 220 | 30 m | GeoTIFF | [EarthExplorer](https://earthexplorer.usgs.gov) | Archived (2000-2017) |
+| PACE/OCI | NASA | 340-2260 nm | 289 | 1.2 km | NetCDF4 | [Ocean Color Web](https://oceancolor.gsfc.nasa.gov) | Active |
+
+**Planned:**
+
+| Platform | Agency | Bands | Resolution | Launch |
+|----------|--------|-------|-----------|--------|
+| CHIME (Sentinel-10) | ESA/Copernicus | >200 (400-2500 nm) | 30 m | 2028/2030 |
+| SBG | NASA/JPL | VSWIR + TIR | ~30/60 m | 2028+ |
+
+---
+
+## Thermal / Infrared
+
+| Platform | Agency | Thermal Range | Bands | Resolution | Format | Download | Status |
+|----------|--------|--------------|-------|-----------|--------|----------|--------|
+| ECOSTRESS (ISS) | NASA/JPL | 8-12.5 um | 5 TIR + 1 SWIR | ~70 m | HDF5, COG | [NASA Earthdata](https://search.earthdata.nasa.gov) | Active |
+| Landsat 8/9 TIRS | NASA/USGS | 10.6-12.5 um | 2 | 100 m (resampled 30 m) | GeoTIFF (COG) | [EarthExplorer](https://earthexplorer.usgs.gov) | Active |
+| ASTER TIR | NASA/METI | 8.1-11.7 um | 5 | 90 m | HDF-EOS | [EarthExplorer](https://earthexplorer.usgs.gov) | Active |
+| MODIS thermal | NASA | 3.7-14.4 um | 16 emissive | 1000 m | HDF-EOS | [LAADS DAAC](https://ladsweb.modaps.eosdis.nasa.gov) | Active (aging) |
+| VIIRS thermal | NASA/NOAA | 3.7-12.5 um | I4, I5, M12-M16 | 375/750 m | HDF5, NetCDF | [LAADS DAAC](https://ladsweb.modaps.eosdis.nasa.gov) | Active |
+
+---
+
+## LiDAR / Altimetry
+
+| Platform | Agency | Instrument | Footprint | Format | Download | Status |
+|----------|--------|-----------|-----------|--------|----------|--------|
+| ICESat-2 | NASA | ATLAS (532 nm photon-counting) | ~14 m, 6 beams | HDF5 | [NSIDC](https://nsidc.org/data/icesat-2/data), [OpenAltimetry](https://openaltimetry.org) | Active |
+| GEDI (ISS) | NASA/UMD | Full-waveform 1064 nm | ~25 m, 8 tracks | HDF5 | [LP DAAC](https://lpdaac.usgs.gov), [ORNL DAAC](https://daac.ornl.gov) | Active (EOL Jan 2031) |
+| CALIPSO | NASA/CNES | CALIOP (532+1064 nm) | 333 m along-track | HDF4 | [NASA ASDC](https://asdc.larc.nasa.gov/project/CALIPSO) | Decommissioned (2006-2023 archive) |
+| USGS 3DEP | USGS | Airborne LiDAR | 2-8+ pts/m2 | LAZ, GeoTIFF (DEMs) | [LiDAR Explorer](https://apps.nationalmap.gov/lidar-explorer/), [3DEP on AWS](https://registry.opendata.aws/usgs-lidar/) | Ongoing |
+
+---
+
+## Geostationary Weather / Environmental
+
+| Platform | Agency | Bands | Resolution | Cadence | Format | Download | Status |
+|----------|--------|-------|-----------|---------|--------|----------|--------|
+| GOES-16/18/19 | NOAA/NASA | 16 (0.47-13.3 um) | 0.5-2 km | 5-10 min | NetCDF4 | [NOAA CLASS](https://www.avl.class.noaa.gov), [GOES on AWS](https://registry.opendata.aws/noaa-goes/) | Active |
+| Himawari-8/9 | JMA (Japan) | 16 (0.47-13.3 um) | 0.5-2 km | 2.5-10 min | HSD (Himawari Standard) | [Himawari on AWS](https://registry.opendata.aws/noaa-himawari/), [JAXA P-Tree](https://www.eorc.jaxa.jp/ptree/) | Active |
+| Meteosat MSG/MTG | EUMETSAT | 12 (SEVIRI) | 1-3 km | 5-15 min | HRIT/LRIT, NetCDF | [EUMETSAT Data Store](https://data.eumetsat.int) | Active |
+| INSAT-3D/3DR | ISRO (India) | 6 (VIS-TIR) | 1-8 km | 15 min | HDF5 | [MOSDAC](https://mosdac.gov.in) | Active |
+
+---
+
+## Ocean Color
+
+| Platform | Agency | Spectral Range | Bands | Resolution | Format | Download | Status |
+|----------|--------|---------------|-------|-----------|--------|----------|--------|
+| PACE/OCI | NASA | 340-2260 nm | 289 | 1.2 km | NetCDF4 | [Ocean Color Web](https://oceancolor.gsfc.nasa.gov) | Active |
+| Sentinel-3 OLCI | ESA/EUMETSAT | 400-1020 nm | 21 | 300 m | NetCDF4 (SAFE) | [Copernicus Data Space](https://dataspace.copernicus.eu) | Active |
+| MODIS ocean color | NASA | 412-869 nm | 9 | 1000 m | HDF-EOS, NetCDF | [Ocean Color Web](https://oceancolor.gsfc.nasa.gov) | Active |
+
+---
+
+## Data Distribution Portals
+
+| Portal | URL | Key Missions | API | Registration |
+|--------|-----|-------------|-----|--------------|
+| USGS EarthExplorer | https://earthexplorer.usgs.gov | Landsat, ASTER, NAIP | M2M REST, STAC | Free EROS account |
+| NASA Earthdata | https://earthdata.nasa.gov | All NASA missions | CMR, CMR-STAC, AppEEARS | Free EDL login |
+| Copernicus Data Space | https://dataspace.copernicus.eu | Sentinel-1/2/3/5P | STAC, OData, openEO | Free |
+| Google Earth Engine | https://earthengine.google.com | 900+ datasets | Proprietary (`ee` Python) | Free (research) |
+| Planetary Computer | https://planetarycomputer.microsoft.com | Landsat, S-2, HLS, NAIP, MODIS | STAC (`pystac-client`) | None for search |
+| AWS Open Data | https://registry.opendata.aws | Landsat, S-2, NAIP, GOES, Maxar | STAC (Element 84) | None |
+| Planet Explorer | https://planet.com/explorer | PlanetScope, SkySat | REST, Orders API | Commercial |
+| Maxar Open Data | https://maxar.com/open-data | WorldView, GeoEye | STAC on AWS S3 | None |
+| NOAA CLASS | https://www.avl.class.noaa.gov | GOES, JPSS/VIIRS | Web-based ordering | Free |
+| JAXA G-Portal | https://gportal.jaxa.jp | ALOS, GCOM, GPM | `jaxa-earth-api` | Free |
+| ASI PRISMA | https://prisma.asi.it | PRISMA hyperspectral | Web portal only | Free |
+| DLR EOWEB | https://eoweb.dlr.de | EnMAP hyperspectral | EOWEB, EOC Geoservice | Free |
+
+**Key ecosystem libraries:**
+- `earthaccess` -- NASA Earthdata auth, CMR search, download/streaming
+- `pystac-client` -- STAC API client (Planetary Computer, AWS, Copernicus)
+- `planetary-computer` -- Azure SAS token signing for Planetary Computer
+- `sentinelsat` -- Copernicus Sentinel search/download
+- `planet` -- Planet SDK for Python (PlanetScope, SkySat)
+
+---
+
+## File Formats and GRDL Reader Status
+
+| Format | Extensions | Used By | Python Backend | GRDL Status |
+|--------|-----------|---------|---------------|-------------|
+| GeoTIFF / COG | `.tif`, `.tiff` | Landsat, Planet, Maxar, HLS, NAIP, EnMAP | `rasterio` | **Implemented** |
+| NITF | `.nitf`, `.ntf` | WorldView, SkySat, NGA products | `rasterio`/GDAL | **Implemented** |
+| HDF5 / HDF-EOS5 | `.h5`, `.he5`, `.hdf5` | NASA (MODIS, VIIRS, ICESat-2, GEDI, EMIT), PRISMA, JAXA | `h5py`, `xarray` | **Implemented** |
+| JPEG2000 | `.jp2`, `.j2k` | Sentinel-2, EnMAP, Pleiades | `rasterio`/GDAL, `glymur` | Not implemented |
+| HDF4 / HDF-EOS | `.hdf`, `.he4` | MODIS (legacy), ASTER, CALIPSO | `pyhdf`, GDAL | Not implemented |
+| NetCDF-4 | `.nc`, `.nc4` | NOAA (GOES, JPSS), Sentinel-3/5P, PACE, ocean color | `xarray`, `netCDF4` | Not implemented |
+| SAFE | `.SAFE` (dir) | All Sentinel missions | XML + format readers | Not implemented |
+| ENVI | `.hdr` + `.bil`/`.bip`/`.bsq` | EnMAP, AVIRIS, airborne hyperspectral | `spectral`, numpy mmap | Not implemented |
+| LAS/LAZ | `.las`, `.laz` | USGS 3DEP, LiDAR datasets | `laspy`, PDAL | Not implemented (point cloud) |
+| Zarr | `.zarr` (dir) | Planetary Computer, ERA5, cloud-native | `zarr`, `xarray` | Not implemented |
+| DIMAP | `.dim` + GeoTIFF/JP2 | Pleiades, SPOT (Airbus) | XML + `rasterio` | Not implemented |
+
+---
+
+## Reader Implementation Priorities
+
+### Priority 1 -- HDF5Reader
+
+Unlocks the largest number of new platforms: NASA Earthdata (MODIS, VIIRS, ASTER, ICESat-2, GEDI, EMIT), PRISMA hyperspectral, JAXA missions.
+
+- **Backend:** `h5py`
+- **Key challenge:** HDF5 is hierarchical -- datasets live at arbitrary paths. Need convention for dataset selection (by path, by index, or auto-detect).
+- **Scope:** Single-dataset raster reads. Not a general HDF5 browser.
+
+### Priority 2 -- NetCDF4Reader
+
+Shares HDF5 infrastructure (NetCDF-4 is built on HDF5). Unlocks NOAA (GOES, JPSS/VIIRS), Sentinel-3 OLCI/SLSTR, Sentinel-5P, PACE ocean color, climate data.
+
+- **Backend:** `xarray` with `h5netcdf` or `netCDF4` engine
+- **Key challenge:** CF conventions, coordinate variables, multi-dimensional data
+- **Scope:** Variable-based reads with coordinate subsetting
+
+### Priority 3 -- JP2Reader
+
+Unlocks Sentinel-2 native format (SAFE/JP2). Note: `rasterio` may already handle JP2 if GDAL was compiled with OpenJPEG support.
+
+- **Backend:** `rasterio` (GDAL JP2 driver) or `glymur` (for S-2 non-standard 15-bit)
+- **Key challenge:** Sentinel-2 encodes 15-bit data in JP2; some GDAL builds lack JP2 support
+- **Scope:** Single-band JP2 reads, consistent with GeoTIFFReader API
+
+### Priority 4 -- ENVIReader
+
+Unlocks airborne/spaceborne hyperspectral workflows (EnMAP BSQ/BIL/BIP, AVIRIS, HySpex).
+
+- **Backend:** `spectral` (SPy) or raw numpy memmap
+- **Key challenge:** Three interleave modes (BSQ, BIL, BIP), ASCII header parsing
+- **Scope:** Band-sequential and band-interleaved reads with wavelength metadata
+
+### Priority 5 -- SAFEReader
+
+Makes Sentinel products "just work" as directories. Parses `manifest.safe` XML, delegates to JP2/GeoTIFF/NetCDF readers for actual imagery.
+
+- **Backend:** `xml.etree` + existing GRDL readers
+- **Key challenge:** Complex directory structure varies by Sentinel mission
+- **Scope:** Sentinel-2 SAFE initially, extensible to S-1/S-3
+
+### Lower Priority
+
+- **DIMAP** -- Airbus Pleiades/SPOT. XML manifest + GeoTIFF/JP2. Commercial data access.
+- **Zarr** -- Better served by `xarray` integration than a dedicated reader.
+- **LAS/LAZ** -- Point cloud data, fundamentally different from 2D raster model.
+- **HDF4** -- Legacy. MODIS HDF4 being superseded by HDF5/NetCDF products.
+
+---
+
+## Format-to-Platform Coverage Matrix
+
+Shows which platforms each reader implementation would unlock:
+
+| Reader | Platforms Unlocked |
+|--------|--------------------|
+| GeoTIFF (**done**) | Landsat, HLS, NAIP, Maxar Open Data, Planet, CBERS, Gaofen, VENuS, EnMAP (optional), 3DEP DEMs |
+| NITF (**done**) | WorldView, SkySat, NGA products |
+| HDF5 (**done**) | MODIS, VIIRS, ASTER, ICESat-2, GEDI, EMIT, PRISMA, ECOSTRESS, HISUI, INSAT |
+| NetCDF4 (Priority 2) | GOES, JPSS/VIIRS, Sentinel-3 OLCI/SLSTR, Sentinel-5P, PACE/OCI, Himawari, Meteosat |
+| JP2 (Priority 3) | Sentinel-2 (native), Pleiades, SPOT, EnMAP (optional) |
+| ENVI (Priority 4) | EnMAP, AVIRIS, HySpex, airborne hyperspectral |
+| SAFE (Priority 5) | Sentinel-1/2/3 (directory-level access) |

--- a/tests/test_io_hdf5.py
+++ b/tests/test_io_hdf5.py
@@ -1,0 +1,412 @@
+# -*- coding: utf-8 -*-
+"""
+HDF5 Reader Tests - Unit tests for HDF5Reader.
+
+Uses synthetic HDF5 files created with h5py for testing.
+
+Dependencies
+------------
+pytest
+h5py
+
+Author
+------
+Duane Smalley, PhD
+duane.d.smalley@gmail.com
+
+License
+-------
+MIT License
+Copyright (c) 2024 geoint.org
+See LICENSE file for full text.
+
+Created
+-------
+2026-02-10
+
+Modified
+--------
+2026-02-10
+"""
+
+import pytest
+import numpy as np
+from pathlib import Path
+
+try:
+    import h5py
+    _HAS_H5PY = True
+except ImportError:
+    _HAS_H5PY = False
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_H5PY, reason="h5py not installed"
+)
+
+
+@pytest.fixture
+def single_band_h5(tmp_path):
+    """Create an HDF5 file with a single 2D dataset."""
+    filepath = tmp_path / "test_single.h5"
+    data = np.random.rand(100, 200).astype(np.float32)
+
+    with h5py.File(str(filepath), "w") as f:
+        f.attrs["producer"] = "test"
+        ds = f.create_dataset("image", data=data)
+        ds.attrs["units"] = "reflectance"
+
+    return filepath, data
+
+
+@pytest.fixture
+def multi_band_h5(tmp_path):
+    """Create an HDF5 file with a 3D dataset (bands, rows, cols)."""
+    filepath = tmp_path / "test_multi.h5"
+    data = np.random.rand(3, 80, 120).astype(np.float32)
+
+    with h5py.File(str(filepath), "w") as f:
+        f.create_dataset("bands", data=data)
+
+    return filepath, data
+
+
+@pytest.fixture
+def nested_h5(tmp_path):
+    """Create an HDF5 file with datasets in nested groups."""
+    filepath = tmp_path / "test_nested.h5"
+    data_a = np.random.rand(50, 60).astype(np.float32)
+    data_b = np.random.rand(4, 50, 60).astype(np.float64)
+
+    with h5py.File(str(filepath), "w") as f:
+        grp = f.create_group("HDFEOS/GRIDS/VNP_Grid")
+        grp.create_dataset("NDVI", data=data_a)
+        grp.create_dataset("Bands", data=data_b)
+        # Also add a 1D dataset that should be skipped by auto-detect
+        f.create_dataset("timestamps", data=np.arange(100))
+
+    return filepath, data_a, data_b
+
+
+@pytest.fixture
+def geo_h5(tmp_path):
+    """Create an HDF5 file with geolocation attributes."""
+    filepath = tmp_path / "test_geo.h5"
+    data = np.random.rand(64, 64).astype(np.float32)
+
+    with h5py.File(str(filepath), "w") as f:
+        f.attrs["crs"] = "EPSG:4326"
+        f.attrs["geospatial_lat_min"] = -31.5
+        f.attrs["geospatial_lat_max"] = -30.5
+        f.attrs["geospatial_lon_min"] = 115.5
+        f.attrs["geospatial_lon_max"] = 116.8
+        ds = f.create_dataset("data", data=data)
+        ds.attrs["scale_factor"] = 0.0001
+
+    return filepath, data
+
+
+# -- Metadata tests ---------------------------------------------------------
+
+def test_metadata_single_band(single_band_h5):
+    """Metadata extracted correctly from single 2D dataset."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, _ = single_band_h5
+    with HDF5Reader(filepath) as reader:
+        assert reader.metadata['format'] == 'HDF5'
+        assert reader.metadata['rows'] == 100
+        assert reader.metadata['cols'] == 200
+        assert reader.metadata['bands'] == 1
+        assert reader.metadata['dtype'] == 'float32'
+        assert reader.metadata['dataset_path'] == '/image'
+
+
+def test_metadata_multi_band(multi_band_h5):
+    """Metadata extracted correctly from 3D dataset."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, _ = multi_band_h5
+    with HDF5Reader(filepath) as reader:
+        assert reader.metadata['bands'] == 3
+        assert reader.metadata['rows'] == 80
+        assert reader.metadata['cols'] == 120
+
+
+def test_metadata_includes_attributes(single_band_h5):
+    """HDF5 attributes propagated to metadata extras."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, _ = single_band_h5
+    with HDF5Reader(filepath) as reader:
+        assert reader.metadata['units'] == 'reflectance'
+        assert reader.metadata['file_producer'] == 'test'
+
+
+# -- Auto-detection tests ---------------------------------------------------
+
+def test_auto_detect_selects_first_2d(nested_h5):
+    """Auto-detect picks a 2D+ dataset, skipping 1D."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, data_a, _ = nested_h5
+    with HDF5Reader(filepath) as reader:
+        # Should select one of the 2D+ datasets, not the 1D timestamps
+        assert reader.dataset_path in (
+            '/HDFEOS/GRIDS/VNP_Grid/NDVI',
+            '/HDFEOS/GRIDS/VNP_Grid/Bands',
+        )
+        assert reader.metadata['rows'] == 50
+        assert reader.metadata['cols'] == 60
+
+
+def test_explicit_dataset_path(nested_h5):
+    """Explicit dataset_path selects the requested dataset."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, _, data_b = nested_h5
+    with HDF5Reader(filepath, dataset_path='/HDFEOS/GRIDS/VNP_Grid/Bands') as reader:
+        assert reader.metadata['bands'] == 4
+        assert reader.metadata['rows'] == 50
+        assert reader.metadata['cols'] == 60
+
+
+def test_invalid_dataset_path_raises(single_band_h5):
+    """Invalid dataset_path raises ValueError with available paths."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, _ = single_band_h5
+    with pytest.raises(ValueError, match="not found"):
+        HDF5Reader(filepath, dataset_path='/nonexistent')
+
+
+def test_no_suitable_dataset_raises(tmp_path):
+    """File with only 1D data raises ValueError."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath = tmp_path / "only_1d.h5"
+    with h5py.File(str(filepath), "w") as f:
+        f.create_dataset("vector", data=np.arange(100))
+
+    with pytest.raises(ValueError, match="No 2D"):
+        HDF5Reader(filepath)
+
+
+# -- Shape and dtype tests --------------------------------------------------
+
+def test_get_shape_single_band(single_band_h5):
+    """get_shape returns (rows, cols) for single band."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, _ = single_band_h5
+    with HDF5Reader(filepath) as reader:
+        assert reader.get_shape() == (100, 200)
+
+
+def test_get_shape_multi_band(multi_band_h5):
+    """get_shape returns (rows, cols, bands) for multi-band."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, _ = multi_band_h5
+    with HDF5Reader(filepath) as reader:
+        assert reader.get_shape() == (80, 120, 3)
+
+
+def test_get_dtype(single_band_h5):
+    """get_dtype returns correct numpy dtype."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, _ = single_band_h5
+    with HDF5Reader(filepath) as reader:
+        assert reader.get_dtype() == np.dtype('float32')
+
+
+# -- Read tests --------------------------------------------------------------
+
+def test_read_chip_single_band(single_band_h5):
+    """read_chip returns correct data for single 2D dataset."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, original = single_band_h5
+    with HDF5Reader(filepath) as reader:
+        chip = reader.read_chip(10, 30, 20, 50)
+        assert chip.shape == (20, 30)
+        np.testing.assert_array_almost_equal(
+            chip, original[10:30, 20:50]
+        )
+
+
+def test_read_chip_multi_band(multi_band_h5):
+    """read_chip returns correct data for 3D dataset."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, original = multi_band_h5
+    with HDF5Reader(filepath) as reader:
+        chip = reader.read_chip(0, 40, 0, 60)
+        assert chip.shape == (3, 40, 60)
+        np.testing.assert_array_almost_equal(
+            chip, original[:, :40, :60]
+        )
+
+
+def test_read_chip_band_selection(multi_band_h5):
+    """read_chip with specific bands returns correct data."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, original = multi_band_h5
+    with HDF5Reader(filepath) as reader:
+        chip = reader.read_chip(0, 40, 0, 60, bands=[1])
+        assert chip.shape == (40, 60)
+        np.testing.assert_array_almost_equal(
+            chip, original[1, :40, :60]
+        )
+
+
+def test_read_full_single_band(single_band_h5):
+    """read_full returns entire image for single band."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, original = single_band_h5
+    with HDF5Reader(filepath) as reader:
+        full = reader.read_full()
+        assert full.shape == (100, 200)
+        np.testing.assert_array_almost_equal(full, original)
+
+
+def test_read_full_multi_band(multi_band_h5):
+    """read_full returns all bands."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, original = multi_band_h5
+    with HDF5Reader(filepath) as reader:
+        full = reader.read_full()
+        assert full.shape == (3, 80, 120)
+        np.testing.assert_array_almost_equal(full, original)
+
+
+def test_read_full_band_selection(multi_band_h5):
+    """read_full with band selection returns correct subset."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, original = multi_band_h5
+    with HDF5Reader(filepath) as reader:
+        data = reader.read_full(bands=[0, 2])
+        assert data.shape == (2, 80, 120)
+        np.testing.assert_array_almost_equal(data[0], original[0])
+        np.testing.assert_array_almost_equal(data[1], original[2])
+
+
+# -- Validation tests --------------------------------------------------------
+
+def test_read_chip_negative_start_raises(single_band_h5):
+    """Negative start indices raise ValueError."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, _ = single_band_h5
+    with HDF5Reader(filepath) as reader:
+        with pytest.raises(ValueError, match="non-negative"):
+            reader.read_chip(-1, 10, 0, 10)
+
+
+def test_read_chip_out_of_bounds_raises(single_band_h5):
+    """Out-of-bounds end indices raise ValueError."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, _ = single_band_h5
+    with HDF5Reader(filepath) as reader:
+        with pytest.raises(ValueError, match="exceed"):
+            reader.read_chip(0, 200, 0, 10)
+
+
+def test_file_not_found():
+    """FileNotFoundError for non-existent file."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    with pytest.raises(FileNotFoundError):
+        HDF5Reader('/nonexistent/file.h5')
+
+
+# -- Geolocation tests -------------------------------------------------------
+
+def test_geolocation_from_attributes(geo_h5):
+    """get_geolocation extracts CRS and extent from attributes."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, _ = geo_h5
+    with HDF5Reader(filepath) as reader:
+        geo = reader.get_geolocation()
+        assert geo is not None
+        assert geo['crs'] == 'EPSG:4326'
+
+
+def test_geolocation_none_when_absent(single_band_h5):
+    """get_geolocation returns None when no geo attributes."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, _ = single_band_h5
+    with HDF5Reader(filepath) as reader:
+        geo = reader.get_geolocation()
+        # File has 'producer' attribute but no geo attributes
+        assert geo is None
+
+
+# -- Context manager and cleanup tests ---------------------------------------
+
+def test_context_manager(single_band_h5):
+    """Context manager opens and closes cleanly."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, _ = single_band_h5
+    with HDF5Reader(filepath) as reader:
+        assert reader.metadata['rows'] == 100
+
+
+def test_close_idempotent(single_band_h5):
+    """Calling close() multiple times does not raise."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, _ = single_band_h5
+    reader = HDF5Reader(filepath)
+    reader.close()
+    reader.close()
+
+
+# -- list_datasets utility tests ---------------------------------------------
+
+def test_list_datasets(nested_h5):
+    """list_datasets returns all 2D+ datasets with paths and shapes."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, _, _ = nested_h5
+    datasets = HDF5Reader.list_datasets(filepath)
+    paths = [p for p, _, _ in datasets]
+    assert '/HDFEOS/GRIDS/VNP_Grid/NDVI' in paths
+    assert '/HDFEOS/GRIDS/VNP_Grid/Bands' in paths
+    # 1D timestamps should NOT appear
+    assert '/timestamps' not in paths
+
+
+def test_list_datasets_min_ndim(nested_h5):
+    """list_datasets with min_ndim=1 includes 1D arrays."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    filepath, _, _ = nested_h5
+    datasets = HDF5Reader.list_datasets(filepath, min_ndim=1)
+    paths = [p for p, _, _ in datasets]
+    assert '/timestamps' in paths
+
+
+def test_list_datasets_file_not_found():
+    """list_datasets raises FileNotFoundError for missing file."""
+    from grdl.IO.hdf5 import HDF5Reader
+
+    with pytest.raises(FileNotFoundError):
+        HDF5Reader.list_datasets('/nonexistent/file.h5')
+
+
+# -- ImageReader ABC contract ------------------------------------------------
+
+def test_is_image_reader_subclass():
+    """HDF5Reader is a subclass of ImageReader."""
+    from grdl.IO.base import ImageReader
+    from grdl.IO.hdf5 import HDF5Reader
+    assert issubclass(HDF5Reader, ImageReader)

--- a/tests/test_io_imports.py
+++ b/tests/test_io_imports.py
@@ -22,7 +22,7 @@ Created
 
 Modified
 --------
-2026-02-09
+2026-02-10
 """
 
 import pytest
@@ -39,10 +39,11 @@ def test_import_base_classes():
 
 
 def test_import_base_format_readers():
-    """GeoTIFF and NITF readers importable from grdl.IO."""
-    from grdl.IO import GeoTIFFReader, NITFReader
+    """GeoTIFF, NITF, and HDF5 readers importable from grdl.IO."""
+    from grdl.IO import GeoTIFFReader, NITFReader, HDF5Reader
     assert GeoTIFFReader is not None
     assert NITFReader is not None
+    assert HDF5Reader is not None
 
 
 def test_import_sar_readers():
@@ -82,6 +83,12 @@ def test_import_nitf_direct():
     """NITFReader importable from grdl.IO.nitf."""
     from grdl.IO.nitf import NITFReader
     assert NITFReader is not None
+
+
+def test_import_hdf5_direct():
+    """HDF5Reader importable from grdl.IO.hdf5."""
+    from grdl.IO.hdf5 import HDF5Reader
+    assert HDF5Reader is not None
 
 
 def test_import_sar_submodule():
@@ -140,6 +147,13 @@ def test_nitf_is_image_reader():
     assert issubclass(NITFReader, ImageReader)
 
 
+def test_hdf5_is_image_reader():
+    """HDF5Reader inherits from ImageReader."""
+    from grdl.IO.base import ImageReader
+    from grdl.IO.hdf5 import HDF5Reader
+    assert issubclass(HDF5Reader, ImageReader)
+
+
 def test_sicd_is_image_reader():
     """SICDReader inherits from ImageReader."""
     from grdl.IO.base import ImageReader
@@ -189,7 +203,7 @@ def test_io_all_exports():
     import grdl.IO as io_mod
     expected = [
         'ImageReader', 'ImageWriter', 'CatalogInterface',
-        'GeoTIFFReader', 'NITFReader',
+        'GeoTIFFReader', 'HDF5Reader', 'NITFReader',
         'SICDReader', 'CPHDReader', 'CRSDReader', 'SIDDReader',
         'BIOMASSL1Reader', 'BIOMASSCatalog',
         'open_image', 'open_sar', 'open_biomass', 'load_credentials',


### PR DESCRIPTION
## Summary
- **HDF5Reader**: New base format reader for HDF5/HDF-EOS5 files (h5py backend), supporting auto-detection or explicit dataset path selection, hyperslab reads, and geolocation extraction from attributes
- **integration.md**: Comprehensive non-SAR remote sensing platform reference (40+ platforms, 12 portals, 11 formats) with reader implementation roadmap
- Updated IO module exports, README, TODO, and import tests for HDF5Reader

## Test plan
- [x] 27 HDF5Reader unit tests (synthetic h5py fixtures) — all passing
- [x] Import and ABC inheritance tests added to test_io_imports.py
- [x] Full test suite: 530 passed, 0 new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)