### PR TITLE
Add TerraSAR-X / TanDEM-X reader with COSAR binary and GeoTIFF support

### DIFF
--- a/grdl/IO/__init__.py
+++ b/grdl/IO/__init__.py
@@ -31,7 +31,7 @@ Created
 
 Modified
 --------
-2026-02-10
+2026-02-19
 """
 
 # Standard library
@@ -46,7 +46,7 @@ import numpy as np
 from grdl.IO.base import ImageReader, ImageWriter, CatalogInterface
 from grdl.IO.models import (
     ImageMetadata, SICDMetadata, SIDDMetadata, BIOMASSMetadata,
-    VIIRSMetadata, ASTERMetadata,
+    VIIRSMetadata, ASTERMetadata, TerraSARMetadata,
 )
 
 # Base format readers (IO level)
@@ -63,8 +63,10 @@ from grdl.IO.sar import (
     SIDDReader,
     BIOMASSL1Reader,
     BIOMASSCatalog,
+    TerraSARReader,
     open_sar,
     open_biomass,
+    open_terrasar,
     load_credentials,
 )
 
@@ -303,6 +305,10 @@ __all__ = [
     # BIOMASS
     'BIOMASSL1Reader',
     'BIOMASSCatalog',
+    # TerraSAR-X / TanDEM-X
+    'TerraSARMetadata',
+    'TerraSARReader',
+    'open_terrasar',
     # IR readers
     'ASTERReader',
     # Multispectral readers

--- a/grdl/IO/models/__init__.py
+++ b/grdl/IO/models/__init__.py
@@ -23,7 +23,7 @@ Created
 
 Modified
 --------
-2026-02-10
+2026-02-19
 """
 
 # Base
@@ -156,6 +156,20 @@ from grdl.IO.models.sentinel1_slc import (
     S1SLCNoiseAzimuthVector,
 )
 
+# TerraSAR-X / TanDEM-X
+from grdl.IO.models.terrasar import (
+    TerraSARMetadata,
+    TSXProductInfo,
+    TSXSceneInfo,
+    TSXImageInfo,
+    TSXRadarParams,
+    TSXOrbitStateVector,
+    TSXGeoGridPoint,
+    TSXCalibration,
+    TSXDopplerInfo,
+    TSXProcessingInfo,
+)
+
 # CPHD
 from grdl.IO.models.cphd import (
     CPHDMetadata,
@@ -286,6 +300,17 @@ __all__ = [
     'S1SLCCalibrationVector',
     'S1SLCNoiseRangeVector',
     'S1SLCNoiseAzimuthVector',
+    # TerraSAR-X / TanDEM-X
+    'TerraSARMetadata',
+    'TSXProductInfo',
+    'TSXSceneInfo',
+    'TSXImageInfo',
+    'TSXRadarParams',
+    'TSXOrbitStateVector',
+    'TSXGeoGridPoint',
+    'TSXCalibration',
+    'TSXDopplerInfo',
+    'TSXProcessingInfo',
     # CPHD
     'CPHDMetadata',
     'CPHDChannel',

--- a/grdl/IO/models/terrasar.py
+++ b/grdl/IO/models/terrasar.py
@@ -1,0 +1,383 @@
+# -*- coding: utf-8 -*-
+"""
+TerraSAR-X / TanDEM-X Metadata - Typed metadata for TSX/TDX SAR products.
+
+Nested dataclasses representing the full annotation, geolocation grid,
+and calibration metadata from TerraSAR-X and TanDEM-X products (SSC,
+MGD, GEC, EEC).  Each reader instance populates one
+``TerraSARMetadata`` with all parsed sections.
+
+Author
+------
+Jason Fritz
+jpfritz@zai.com
+
+License
+-------
+MIT License
+Copyright (c) 2024 geoint.org
+See LICENSE file for full text.
+
+Created
+-------
+2026-02-19
+
+Modified
+--------
+2026-02-19
+"""
+
+# Standard library
+from dataclasses import dataclass
+from typing import List, Optional
+
+# Third-party
+import numpy as np
+
+# GRDL internal
+from grdl.IO.models.base import ImageMetadata
+from grdl.IO.models.common import XYZ, LatLonHAE
+
+
+# ===================================================================
+# Product-level info (from generalHeader + productInfo)
+# ===================================================================
+
+@dataclass
+class TSXProductInfo:
+    """TerraSAR-X / TanDEM-X product-level metadata.
+
+    Parameters
+    ----------
+    mission : str, optional
+        Mission name (``'TerraSAR-X'`` or ``'TanDEM-X'``).
+    satellite : str, optional
+        Satellite identifier (``'TSX-1'`` or ``'TDX-1'``).
+    product_type : str, optional
+        Product type (``'SSC'``, ``'MGD'``, ``'GEC'``, ``'EEC'``).
+    imaging_mode : str, optional
+        Imaging mode (``'SM'``, ``'HS'``, ``'SL'``, ``'SC'``, ``'ST'``).
+    look_direction : str, optional
+        Look direction (``'RIGHT'`` or ``'LEFT'``).
+    polarization_mode : str, optional
+        Polarization class (``'SINGLE'``, ``'DUAL'``, ``'TWIN'``,
+        ``'QUAD'``).
+    polarization_list : List[str], optional
+        List of polarization channels (e.g., ``['HH']``,
+        ``['HH', 'VV']``).
+    orbit_direction : str, optional
+        Orbit direction (``'ASCENDING'`` or ``'DESCENDING'``).
+    absolute_orbit : int, optional
+        Absolute orbit number.
+    start_time_utc : str, optional
+        Acquisition start time (ISO 8601 UTC).
+    stop_time_utc : str, optional
+        Acquisition stop time (ISO 8601 UTC).
+    generation_time : str, optional
+        Product generation time (ISO 8601 UTC).
+    processor_version : str, optional
+        SAR processor version string.
+    """
+
+    mission: Optional[str] = None
+    satellite: Optional[str] = None
+    product_type: Optional[str] = None
+    imaging_mode: Optional[str] = None
+    look_direction: Optional[str] = None
+    polarization_mode: Optional[str] = None
+    polarization_list: Optional[List[str]] = None
+    orbit_direction: Optional[str] = None
+    absolute_orbit: Optional[int] = None
+    start_time_utc: Optional[str] = None
+    stop_time_utc: Optional[str] = None
+    generation_time: Optional[str] = None
+    processor_version: Optional[str] = None
+
+
+# ===================================================================
+# Scene info (from productInfo/sceneInfo)
+# ===================================================================
+
+@dataclass
+class TSXSceneInfo:
+    """Scene geographic and geometric information.
+
+    Parameters
+    ----------
+    center_lat : float, optional
+        Scene center latitude in degrees.
+    center_lon : float, optional
+        Scene center longitude in degrees.
+    scene_extent : List[LatLonHAE], optional
+        Scene corner coordinates (typically 4 corners).
+    incidence_angle_near : float, optional
+        Near-range incidence angle in degrees.
+    incidence_angle_far : float, optional
+        Far-range incidence angle in degrees.
+    incidence_angle_center : float, optional
+        Center incidence angle in degrees.
+    heading_angle : float, optional
+        Platform heading angle in degrees from north.
+    """
+
+    center_lat: Optional[float] = None
+    center_lon: Optional[float] = None
+    scene_extent: Optional[List[LatLonHAE]] = None
+    incidence_angle_near: Optional[float] = None
+    incidence_angle_far: Optional[float] = None
+    incidence_angle_center: Optional[float] = None
+    heading_angle: Optional[float] = None
+
+
+# ===================================================================
+# Image info (from productInfo/imageDataInfo)
+# ===================================================================
+
+@dataclass
+class TSXImageInfo:
+    """Image dimensions and sampling parameters.
+
+    Parameters
+    ----------
+    num_rows : int
+        Number of rows (azimuth lines).
+    num_cols : int
+        Number of columns (range samples).
+    row_spacing : float, optional
+        Row (azimuth) pixel spacing in meters.
+    col_spacing : float, optional
+        Column (range) pixel spacing in meters.
+    sample_type : str, optional
+        Data sample type (``'COMPLEX'`` for SSC,
+        ``'DETECTED'`` for MGD/GEC/EEC).
+    data_format : str, optional
+        Data storage format (``'COSAR'`` or ``'GEOTIFF'``).
+    bits_per_sample : int, optional
+        Bits per sample component (e.g., 16 for int16 I/Q).
+    projection : str, optional
+        Data projection (``'SLANTRANGE'``, ``'GROUNDRANGE'``,
+        ``'MAP'``).
+    """
+
+    num_rows: int = 0
+    num_cols: int = 0
+    row_spacing: Optional[float] = None
+    col_spacing: Optional[float] = None
+    sample_type: Optional[str] = None
+    data_format: Optional[str] = None
+    bits_per_sample: Optional[int] = None
+    projection: Optional[str] = None
+
+
+# ===================================================================
+# Radar parameters (from instrument/radarParameters)
+# ===================================================================
+
+@dataclass
+class TSXRadarParams:
+    """Radar instrument parameters.
+
+    Parameters
+    ----------
+    center_frequency : float, optional
+        Center frequency in Hz (~9.65 GHz for X-band).
+    prf : float, optional
+        Pulse Repetition Frequency in Hz.
+    range_bandwidth : float, optional
+        Range chirp bandwidth in Hz.
+    chirp_duration : float, optional
+        Chirp pulse duration in seconds.
+    adc_sampling_rate : float, optional
+        ADC sampling rate in Hz.
+    """
+
+    center_frequency: Optional[float] = None
+    prf: Optional[float] = None
+    range_bandwidth: Optional[float] = None
+    chirp_duration: Optional[float] = None
+    adc_sampling_rate: Optional[float] = None
+
+
+# ===================================================================
+# Orbit state vectors (from platform/orbit/stateVec)
+# ===================================================================
+
+@dataclass
+class TSXOrbitStateVector:
+    """Orbit state vector at a single time.
+
+    Parameters
+    ----------
+    time_utc : str, optional
+        UTC time (ISO 8601).
+    position : XYZ, optional
+        ECF position in meters.
+    velocity : XYZ, optional
+        ECF velocity in m/s.
+    """
+
+    time_utc: Optional[str] = None
+    position: Optional[XYZ] = None
+    velocity: Optional[XYZ] = None
+
+
+# ===================================================================
+# Geolocation grid (from GEOREF.xml)
+# ===================================================================
+
+@dataclass
+class TSXGeoGridPoint:
+    """Geolocation grid tie point from GEOREF.xml.
+
+    The georeference annotation provides a grid of tie points mapping
+    (line, pixel) to (latitude, longitude, height).  Bilinear
+    interpolation over this grid provides pixel-to-geographic
+    transforms.
+
+    Parameters
+    ----------
+    line : float
+        Azimuth line coordinate.
+    pixel : float
+        Range pixel coordinate.
+    latitude : float
+        WGS-84 latitude in degrees.
+    longitude : float
+        WGS-84 longitude in degrees.
+    height : float
+        Height above WGS-84 ellipsoid in meters.
+    incidence_angle : float, optional
+        Local incidence angle in degrees.
+    """
+
+    line: float = 0.0
+    pixel: float = 0.0
+    latitude: float = 0.0
+    longitude: float = 0.0
+    height: float = 0.0
+    incidence_angle: Optional[float] = None
+
+
+# ===================================================================
+# Calibration (from CALDATA.xml)
+# ===================================================================
+
+@dataclass
+class TSXCalibration:
+    """Radiometric calibration data from CALDATA.xml.
+
+    Apply the calibration constant as:
+    ``sigma_nought = Ks * |DN|^2 / sin(incidence_angle)``
+
+    Parameters
+    ----------
+    calibration_constant : float, optional
+        Absolute radiometric calibration factor (Ks).
+    noise_equivalent_beta_nought : float, optional
+        NESZ in beta-nought convention.
+    calibration_type : str, optional
+        Calibration annotation type.
+    """
+
+    calibration_constant: Optional[float] = None
+    noise_equivalent_beta_nought: Optional[float] = None
+    calibration_type: Optional[str] = None
+
+
+# ===================================================================
+# Doppler info (from processing/doppler)
+# ===================================================================
+
+@dataclass
+class TSXDopplerInfo:
+    """Doppler centroid and rate information.
+
+    Parameters
+    ----------
+    doppler_centroid_coefficients : np.ndarray, optional
+        Polynomial coefficients for Doppler centroid vs. range time.
+    reference_time : float, optional
+        Reference time for the Doppler polynomial in seconds.
+    """
+
+    doppler_centroid_coefficients: Optional[np.ndarray] = None
+    reference_time: Optional[float] = None
+
+
+# ===================================================================
+# Processing info (from processing/processingInfo)
+# ===================================================================
+
+@dataclass
+class TSXProcessingInfo:
+    """SAR processing parameters.
+
+    Parameters
+    ----------
+    processor_version : str, optional
+        SAR processor version string.
+    processing_level : str, optional
+        Processing level (e.g., ``'L1B'`` for SSC).
+    range_looks : int, optional
+        Number of range looks.
+    azimuth_looks : int, optional
+        Number of azimuth looks.
+    """
+
+    processor_version: Optional[str] = None
+    processing_level: Optional[str] = None
+    range_looks: Optional[int] = None
+    azimuth_looks: Optional[int] = None
+
+
+# ===================================================================
+# Top-level metadata
+# ===================================================================
+
+@dataclass
+class TerraSARMetadata(ImageMetadata):
+    """Complete typed metadata for a TerraSAR-X / TanDEM-X product.
+
+    Inherits universal fields (``format``, ``rows``, ``cols``, ``dtype``)
+    from ``ImageMetadata`` and adds all TerraSAR-X annotation,
+    geolocation, and calibration metadata as typed fields.
+
+    Parameters
+    ----------
+    product_info : TSXProductInfo, optional
+        Product-level metadata (mission, satellite, mode, times).
+    scene_info : TSXSceneInfo, optional
+        Scene geographic extent and incidence angles.
+    image_info : TSXImageInfo, optional
+        Image dimensions and sampling parameters.
+    radar_params : TSXRadarParams, optional
+        Radar instrument parameters.
+    orbit_state_vectors : List[TSXOrbitStateVector], optional
+        Orbit state vectors (position, velocity vs. time).
+    geolocation_grid : List[TSXGeoGridPoint], optional
+        Geolocation tie-point grid from GEOREF.xml.
+    calibration : TSXCalibration, optional
+        Radiometric calibration constants from CALDATA.xml.
+    doppler_info : TSXDopplerInfo, optional
+        Doppler centroid polynomial.
+    processing_info : TSXProcessingInfo, optional
+        SAR processor parameters.
+
+    Examples
+    --------
+    >>> from grdl.IO.sar import TerraSARReader
+    >>> with TerraSARReader('TSX1_SAR__SSC.../') as reader:
+    ...     meta = reader.metadata
+    ...     print(meta.product_info.satellite)   # 'TSX-1'
+    ...     print(meta.radar_params.center_frequency)  # 9.65e9
+    """
+
+    product_info: Optional[TSXProductInfo] = None
+    scene_info: Optional[TSXSceneInfo] = None
+    image_info: Optional[TSXImageInfo] = None
+    radar_params: Optional[TSXRadarParams] = None
+    orbit_state_vectors: Optional[List[TSXOrbitStateVector]] = None
+    geolocation_grid: Optional[List[TSXGeoGridPoint]] = None
+    calibration: Optional[TSXCalibration] = None
+    doppler_info: Optional[TSXDopplerInfo] = None
+    processing_info: Optional[TSXProcessingInfo] = None

--- a/grdl/IO/sar/terrasar.py
+++ b/grdl/IO/sar/terrasar.py
@@ -1,0 +1,1060 @@
+# -*- coding: utf-8 -*-
+"""
+TerraSAR-X / TanDEM-X Reader - DLR TSX/TDX SAR product reader.
+
+Reads TerraSAR-X and TanDEM-X products from the standard DLR directory
+structure.  Handles both SSC products (COSAR binary complex data) and
+detected products (MGD, GEC, EEC via GeoTIFF).  A single reader
+instance opens one polarization channel.
+
+Annotation, georef, and calibration XMLs are parsed into typed
+``TerraSARMetadata`` dataclasses.  Calibration is **not** applied
+automatically -- the calibration constant is stored in metadata for
+the user to apply as needed.
+
+Dependencies
+------------
+rasterio (only for detected products -- MGD/GEC/EEC via GeoTIFF)
+
+Author
+------
+Jason Fritz
+jpfritz@zai.com
+
+License
+-------
+MIT License
+Copyright (c) 2024 geoint.org
+See LICENSE file for full text.
+
+Created
+-------
+2026-02-19
+
+Modified
+--------
+2026-02-19
+"""
+
+# Standard library
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple, Union
+import struct
+import xml.etree.ElementTree as ET
+
+# Third-party
+import numpy as np
+
+try:
+    import rasterio
+    from rasterio.windows import Window
+    _HAS_RASTERIO = True
+except ImportError:
+    _HAS_RASTERIO = False
+
+# GRDL internal
+from grdl.IO.base import ImageReader
+from grdl.IO.models.common import XYZ, LatLonHAE
+from grdl.IO.models.terrasar import (
+    TerraSARMetadata,
+    TSXProductInfo,
+    TSXSceneInfo,
+    TSXImageInfo,
+    TSXRadarParams,
+    TSXOrbitStateVector,
+    TSXGeoGridPoint,
+    TSXCalibration,
+    TSXDopplerInfo,
+    TSXProcessingInfo,
+)
+
+
+# ===================================================================
+# XML parsing helpers
+# ===================================================================
+
+def _xml_text(
+    elem: Optional[ET.Element], path: str,
+) -> Optional[str]:
+    """Extract text from XML path, returning None if absent."""
+    if elem is None:
+        return None
+    return elem.findtext(path)
+
+
+def _xml_float(
+    elem: Optional[ET.Element], path: str,
+) -> Optional[float]:
+    """Extract float from XML path, returning None if absent."""
+    val = _xml_text(elem, path)
+    return float(val) if val is not None else None
+
+
+def _xml_int(
+    elem: Optional[ET.Element], path: str,
+) -> Optional[int]:
+    """Extract int from XML path, returning None if absent."""
+    val = _xml_text(elem, path)
+    return int(val) if val is not None else None
+
+
+def _strip_namespace(root: ET.Element) -> ET.Element:
+    """Strip XML namespace URIs from all tag names in the tree.
+
+    TerraSAR-X annotation XMLs may include a default namespace
+    declaration.  Stripping it allows ``findtext()`` to work with
+    plain tag names.
+
+    Parameters
+    ----------
+    root : ET.Element
+        Root element of the parsed XML tree.
+
+    Returns
+    -------
+    ET.Element
+        Same root element with namespace prefixes removed.
+    """
+    for elem in root.iter():
+        if '}' in elem.tag:
+            elem.tag = elem.tag.split('}', 1)[1]
+    return root
+
+
+# ===================================================================
+# Annotation XML section extractors
+# ===================================================================
+
+def _extract_product_info(root: ET.Element) -> TSXProductInfo:
+    """Extract product-level metadata from generalHeader + productInfo."""
+    hdr = root.find('generalHeader')
+    pi = root.find('productInfo')
+    acq = pi.find('acquisitionInfo') if pi is not None else None
+    mi = pi.find('missionInfo') if pi is not None else None
+    si = pi.find('sceneInfo') if pi is not None else None
+    proc = root.find('processing')
+
+    # Polarization list
+    pol_list: Optional[List[str]] = None
+    if acq is not None:
+        pol_elems = acq.findall('polarisationList/polLayer')
+        if pol_elems:
+            pol_list = [p.text for p in pol_elems if p.text is not None]
+
+    # TSX XMLs use 'mission' in generalHeader for the satellite ID
+    # (e.g. 'TSX-1').  Some products may also include 'satellite'.
+    mission_name = _xml_text(hdr, 'mission') or _xml_text(mi, 'mission')
+    satellite_name = _xml_text(hdr, 'satellite') or mission_name
+
+    return TSXProductInfo(
+        mission=mission_name,
+        satellite=satellite_name,
+        generation_time=_xml_text(hdr, 'generationTime'),
+        product_type=(
+            _xml_text(pi, 'productVariantInfo/productVariant')
+            or _xml_text(pi, 'productVariantInfo/productType')
+        ) if pi is not None else None,
+        imaging_mode=_xml_text(acq, 'imagingMode'),
+        look_direction=_xml_text(acq, 'lookDirection'),
+        polarization_mode=_xml_text(acq, 'polarisationMode'),
+        polarization_list=pol_list,
+        orbit_direction=_xml_text(mi, 'orbitDirection'),
+        absolute_orbit=_xml_int(mi, 'absOrbit'),
+        start_time_utc=_xml_text(si, 'start/timeUTC'),
+        stop_time_utc=_xml_text(si, 'stop/timeUTC'),
+        processor_version=_xml_text(
+            proc, 'processingInfo/processorVersion'
+        ) if proc is not None else None,
+    )
+
+
+def _extract_scene_info(root: ET.Element) -> TSXSceneInfo:
+    """Extract scene geometry from productInfo/sceneInfo."""
+    si = root.find('productInfo/sceneInfo')
+    if si is None:
+        return TSXSceneInfo()
+
+    # Scene corners
+    corners: Optional[List[LatLonHAE]] = None
+    corner_elems = si.findall('sceneCornerCoord')
+    if corner_elems:
+        corners = []
+        for c in corner_elems:
+            corners.append(LatLonHAE(
+                lat=float(c.findtext('lat') or 0),
+                lon=float(c.findtext('lon') or 0),
+                hae=float(c.findtext('height') or 0),
+            ))
+
+    center = si.find('sceneCenterCoord')
+
+    return TSXSceneInfo(
+        center_lat=_xml_float(center, 'lat'),
+        center_lon=_xml_float(center, 'lon'),
+        scene_extent=corners,
+        incidence_angle_near=_xml_float(si, 'rangeNearIncidenceAngle'),
+        incidence_angle_far=_xml_float(si, 'rangeFarIncidenceAngle'),
+        incidence_angle_center=_xml_float(center, 'incidenceAngle')
+        if center is not None else None,
+        heading_angle=_xml_float(si, 'headingAngle'),
+    )
+
+
+def _extract_image_info(root: ET.Element) -> TSXImageInfo:
+    """Extract image dimensions and type from productInfo/imageDataInfo."""
+    idi = root.find('productInfo/imageDataInfo')
+    raster = idi.find('imageRaster') if idi is not None else None
+
+    # Try productSpecific for projection info on SSC products
+    ps = root.find('productSpecific/complexImageInfo')
+    projection = _xml_text(ps, 'projection') if ps is not None else None
+    if projection is None and raster is not None:
+        projection = _xml_text(raster, 'projection')
+
+    return TSXImageInfo(
+        num_rows=_xml_int(raster, 'numberOfRows') or 0,
+        num_cols=_xml_int(raster, 'numberOfColumns') or 0,
+        row_spacing=_xml_float(raster, 'rowSpacing'),
+        col_spacing=_xml_float(raster, 'columnSpacing'),
+        sample_type=_xml_text(idi, 'imageDataType'),
+        data_format=_xml_text(idi, 'imageDataFormat'),
+        bits_per_sample=_xml_int(raster, 'bitsPerSample'),
+        projection=projection,
+    )
+
+
+def _extract_radar_params(root: ET.Element) -> TSXRadarParams:
+    """Extract radar parameters from instrument/radarParameters.
+
+    PRF and bandwidth may be under ``productSpecific/complexImageInfo``
+    (as commonPRF / commonRSF) or nested inside
+    ``instrument/settings/settingRecord/PRF``.  We search all locations.
+    """
+    rp = root.find('instrument/radarParameters')
+    ps = root.find('productSpecific/complexImageInfo')
+
+    # PRF: try complexImageInfo first, then settingRecord, then rp
+    prf = _xml_float(ps, 'commonPRF') if ps is not None else None
+    if prf is None:
+        prf = _xml_float(
+            root, 'instrument/settings/settingRecord/PRF'
+        )
+    if prf is None:
+        prf = _xml_float(rp, 'prf')
+
+    # Bandwidth: try settings/rxBandwidth, then rp/totalBandwidth
+    bw = _xml_float(root, 'instrument/settings/rxBandwidth')
+    if bw is None:
+        bw = _xml_float(rp, 'totalBandwidth')
+
+    # ADC sampling rate: try complexImageInfo/commonRSF, then settings
+    adc = _xml_float(ps, 'commonRSF') if ps is not None else None
+    if adc is None:
+        adc = _xml_float(root, 'instrument/settings/RSF')
+    if adc is None:
+        adc = _xml_float(rp, 'adcSamplingRate')
+
+    return TSXRadarParams(
+        center_frequency=_xml_float(rp, 'centerFrequency'),
+        prf=prf,
+        range_bandwidth=bw,
+        chirp_duration=_xml_float(rp, 'chirpDuration'),
+        adc_sampling_rate=adc,
+    )
+
+
+def _extract_orbit_state_vectors(
+    root: ET.Element,
+) -> List[TSXOrbitStateVector]:
+    """Extract orbit state vectors from platform/orbit/stateVec."""
+    orbit = root.find('platform/orbit')
+    if orbit is None:
+        return []
+
+    vectors: List[TSXOrbitStateVector] = []
+    for sv in orbit.findall('stateVec'):
+        position = XYZ(
+            x=float(sv.findtext('posX') or 0),
+            y=float(sv.findtext('posY') or 0),
+            z=float(sv.findtext('posZ') or 0),
+        )
+        velocity = XYZ(
+            x=float(sv.findtext('velX') or 0),
+            y=float(sv.findtext('velY') or 0),
+            z=float(sv.findtext('velZ') or 0),
+        )
+        vectors.append(TSXOrbitStateVector(
+            time_utc=sv.findtext('timeUTC'),
+            position=position,
+            velocity=velocity,
+        ))
+
+    return vectors
+
+
+def _extract_doppler_info(root: ET.Element) -> TSXDopplerInfo:
+    """Extract Doppler centroid from processing/doppler."""
+    doppler = root.find('processing/doppler')
+    if doppler is None:
+        return TSXDopplerInfo()
+
+    # Doppler centroid polynomial coefficients
+    coef_elem = doppler.find('dopplerCentroid')
+    coefs: Optional[np.ndarray] = None
+    ref_time: Optional[float] = None
+
+    if coef_elem is not None:
+        ref_time = _xml_float(coef_elem, 'referenceTime')
+        coef_values = coef_elem.findall('coefficient')
+        if coef_values:
+            coefs = np.array(
+                [float(c.text) for c in coef_values if c.text is not None],
+                dtype=np.float64,
+            )
+        else:
+            # Some products store as space-separated text
+            coef_text = coef_elem.findtext('dopplerCentroidPolynomial')
+            if coef_text is not None and coef_text.strip():
+                coefs = np.array(
+                    [float(x) for x in coef_text.split()],
+                    dtype=np.float64,
+                )
+
+    return TSXDopplerInfo(
+        doppler_centroid_coefficients=coefs,
+        reference_time=ref_time,
+    )
+
+
+def _extract_processing_info(root: ET.Element) -> TSXProcessingInfo:
+    """Extract processing info from processing/processingInfo."""
+    pi = root.find('processing/processingInfo')
+    if pi is None:
+        return TSXProcessingInfo()
+
+    return TSXProcessingInfo(
+        processor_version=_xml_text(pi, 'processorVersion'),
+        processing_level=_xml_text(pi, 'processingLevel'),
+        range_looks=_xml_int(pi, 'rangeLooks'),
+        azimuth_looks=_xml_int(pi, 'azimuthLooks'),
+    )
+
+
+# ===================================================================
+# GEOREF.xml extractor
+# ===================================================================
+
+def _extract_geolocation_grid(
+    georef_path: Path,
+) -> List[TSXGeoGridPoint]:
+    """Parse geolocation grid tie points from GEOREF.xml.
+
+    Parameters
+    ----------
+    georef_path : Path
+        Path to the GEOREF.xml file.
+
+    Returns
+    -------
+    List[TSXGeoGridPoint]
+        Geolocation grid points.
+    """
+    if not georef_path.exists():
+        return []
+
+    tree = ET.parse(str(georef_path))
+    root = _strip_namespace(tree.getroot())
+
+    points: List[TSXGeoGridPoint] = []
+    for gp in root.iter('gridPoint'):
+        points.append(TSXGeoGridPoint(
+            line=float(gp.findtext('lin') or gp.findtext('line') or 0),
+            pixel=float(gp.findtext('pix') or gp.findtext('pixel') or 0),
+            latitude=float(gp.findtext('lat') or 0),
+            longitude=float(gp.findtext('lon') or 0),
+            height=float(gp.findtext('height') or 0),
+            incidence_angle=_xml_float(gp, 'incidenceAngle'),
+        ))
+
+    return points
+
+
+# ===================================================================
+# CALDATA.xml extractor
+# ===================================================================
+
+def _extract_calibration(caldata_path: Path) -> TSXCalibration:
+    """Parse calibration data from CALDATA.xml.
+
+    Parameters
+    ----------
+    caldata_path : Path
+        Path to the CALDATA.xml file.
+
+    Returns
+    -------
+    TSXCalibration
+        Calibration metadata.
+    """
+    if not caldata_path.exists():
+        return TSXCalibration()
+
+    tree = ET.parse(str(caldata_path))
+    root = _strip_namespace(tree.getroot())
+
+    return TSXCalibration(
+        calibration_constant=_xml_float(root, './/calFactor'),
+        noise_equivalent_beta_nought=_xml_float(
+            root, './/noiseEquivalentBetaNought'
+        ),
+        calibration_type=_xml_text(root, './/calibrationType'),
+    )
+
+
+# ===================================================================
+# Directory resolution
+# ===================================================================
+
+def _resolve_tsx_product_dir(
+    filepath: Path,
+) -> Tuple[Path, Path]:
+    """Resolve path to the TSX product directory and main annotation XML.
+
+    Accepts either:
+    - The product directory directly (contains the main XML).
+    - The main annotation XML file itself.
+    - A data file within the product tree (walks up to find it).
+
+    Parameters
+    ----------
+    filepath : Path
+        User-provided path.
+
+    Returns
+    -------
+    product_dir : Path
+        The product directory root.
+    main_xml : Path
+        Path to the main annotation XML file.
+
+    Raises
+    ------
+    ValueError
+        If no valid TerraSAR-X product structure is found.
+    """
+    filepath = filepath.resolve()
+
+    if filepath.is_dir():
+        xml_file = _find_main_xml(filepath)
+        if xml_file is not None:
+            return filepath, xml_file
+        raise ValueError(
+            f"No TerraSAR-X annotation XML found in: {filepath}"
+        )
+
+    # File path: could be the main XML or a file inside the product
+    if filepath.suffix.lower() == '.xml':
+        parent = filepath.parent
+        # Check if this XML is the main annotation
+        xml_file = _find_main_xml(parent)
+        if xml_file is not None:
+            return parent, xml_file
+
+    # Walk up from a data file (e.g., IMAGEDATA/*.cos)
+    for parent in filepath.parents:
+        xml_file = _find_main_xml(parent)
+        if xml_file is not None:
+            return parent, xml_file
+        if parent == parent.parent:
+            break
+
+    raise ValueError(
+        f"Could not find a TerraSAR-X product directory for: {filepath}"
+    )
+
+
+def _find_main_xml(directory: Path) -> Optional[Path]:
+    """Find the main annotation XML in a product directory.
+
+    Searches for XML files whose name starts with ``TSX1_SAR`` or
+    ``TDX1_SAR``, or matches the directory name.
+
+    Parameters
+    ----------
+    directory : Path
+        Directory to search.
+
+    Returns
+    -------
+    Path or None
+        Main annotation XML path, or None if not found.
+    """
+    dir_name = directory.name
+    for f in sorted(directory.iterdir()):
+        if not f.is_file() or f.suffix.lower() != '.xml':
+            continue
+        name_upper = f.stem.upper()
+        if name_upper.startswith(('TSX1_SAR', 'TDX1_SAR')):
+            return f
+        if f.stem == dir_name:
+            return f
+    return None
+
+
+# ===================================================================
+# COSAR binary format
+# ===================================================================
+
+# COSAR burst header: 8 x uint32 (big-endian)
+#   BIB  – Bytes in Burst (total burst size)
+#   RSRI – Range Sample Real Index (usually 0)
+#   RSNB – Range Samples per line (number of complex samples)
+#   AS   – Azimuth Samples (number of data lines)
+#   BI   – Burst Index (1-based)
+#   RTNB – Range Total Number of Bytes per line (annotation + data)
+#   TNL  – Total Number of Lines (header lines + data lines)
+#   Magic – b'CSAR'
+_COSAR_HEADER_FMT = '>7I4s'
+_COSAR_HEADER_SIZE = struct.calcsize(_COSAR_HEADER_FMT)  # 32 bytes
+
+
+@dataclass
+class _COSARHeader:
+    """Parsed COSAR burst header."""
+
+    rsnb: int           # range samples per line
+    azimuth_lines: int  # number of data lines (AS)
+    rtnb: int           # bytes per range line (including annotation)
+    tnl: int            # total lines (header + data)
+    header_lines: int   # TNL - AS
+    annotation_bytes: int  # RTNB - RSNB * 4  (per data line prefix)
+    sample_size: int    # bytes per I/Q component (derived)
+
+
+def _read_cosar_header(filepath: Path) -> _COSARHeader:
+    """Read COSAR burst header to get image dimensions.
+
+    Parameters
+    ----------
+    filepath : Path
+        Path to ``.cos`` file.
+
+    Returns
+    -------
+    _COSARHeader
+        Parsed header with image dimensions and layout.
+
+    Raises
+    ------
+    ValueError
+        If the file is too small, magic is wrong, or values
+        are invalid.
+    """
+    with open(str(filepath), 'rb') as fh:
+        header_bytes = fh.read(_COSAR_HEADER_SIZE)
+
+    if len(header_bytes) < _COSAR_HEADER_SIZE:
+        raise ValueError(
+            f"COSAR file too small for header: {filepath}"
+        )
+
+    bib, rsri, rsnb, az_samples, bi, rtnb, tnl, magic = (
+        struct.unpack(_COSAR_HEADER_FMT, header_bytes)
+    )
+
+    if magic != b'CSAR':
+        raise ValueError(
+            f"Invalid COSAR magic: {magic!r} (expected b'CSAR')"
+        )
+
+    if az_samples == 0 or rsnb == 0:
+        raise ValueError(
+            f"Invalid COSAR header: azimuth_lines={az_samples}, "
+            f"range_samples={rsnb}"
+        )
+
+    header_lines = tnl - az_samples
+    if header_lines < 0:
+        raise ValueError(
+            f"Invalid COSAR header: TNL={tnl} < AS={az_samples}"
+        )
+
+    # Derive sample size from RTNB and RSNB.
+    # Each complex sample = 2 components (I + Q), each of sample_size
+    # bytes, plus a small per-line annotation prefix.
+    # Typically annotation = 8 bytes, sample_size = 2 (int16 I/Q).
+    # RTNB = annotation + RSNB * 2 * sample_size
+    # Try int16 first (most common), then float32.
+    annot_i2 = rtnb - rsnb * 4
+    annot_f4 = rtnb - rsnb * 8
+
+    if annot_i2 >= 0 and annot_i2 < rsnb:
+        sample_size = 2
+        annotation_bytes = annot_i2
+    elif annot_f4 >= 0 and annot_f4 < rsnb:
+        sample_size = 4
+        annotation_bytes = annot_f4
+    else:
+        raise ValueError(
+            f"Cannot derive COSAR sample size: RTNB={rtnb}, "
+            f"RSNB={rsnb}"
+        )
+
+    return _COSARHeader(
+        rsnb=rsnb,
+        azimuth_lines=az_samples,
+        rtnb=rtnb,
+        tnl=tnl,
+        header_lines=header_lines,
+        annotation_bytes=annotation_bytes,
+        sample_size=sample_size,
+    )
+
+
+def _read_cosar_chip(
+    filepath: Path,
+    row_start: int,
+    row_end: int,
+    col_start: int,
+    col_end: int,
+    header: _COSARHeader,
+) -> np.ndarray:
+    """Read a chip from a COSAR binary file.
+
+    Reads interleaved I/Q sample pairs and returns a complex64 array.
+
+    Parameters
+    ----------
+    filepath : Path
+        Path to ``.cos`` file.
+    row_start : int
+        Starting row (inclusive).
+    row_end : int
+        Ending row (exclusive).
+    col_start : int
+        Starting column (inclusive).
+    col_end : int
+        Ending column (exclusive).
+    header : _COSARHeader
+        Parsed COSAR header.
+
+    Returns
+    -------
+    np.ndarray
+        Complex64 array of shape ``(row_end - row_start,
+        col_end - col_start)``.
+    """
+    rtnb = header.rtnb
+    annotation_bytes = header.annotation_bytes
+    sample_size = header.sample_size
+    data_start_line = header.header_lines
+
+    # Sample dtype for I/Q components (COSAR is big-endian)
+    if sample_size == 2:
+        sample_dtype = np.dtype('>i2')
+    else:
+        sample_dtype = np.dtype('>f4')
+
+    chip_rows = row_end - row_start
+    chip_cols = col_end - col_start
+    result = np.empty((chip_rows, chip_cols), dtype=np.complex64)
+
+    with open(str(filepath), 'rb') as fh:
+        for i, row in enumerate(range(row_start, row_end)):
+            # Offset: (header_lines + row) * RTNB + annotation
+            # + col_start * 2 * sample_size  (I/Q pair)
+            line_offset = (
+                (data_start_line + row) * rtnb
+                + annotation_bytes
+                + col_start * 2 * sample_size
+            )
+            fh.seek(line_offset)
+
+            # Read I/Q pairs for the requested columns
+            raw = fh.read(chip_cols * 2 * sample_size)
+            iq = np.frombuffer(raw, dtype=sample_dtype)
+            iq = iq.reshape(chip_cols, 2)
+
+            result[i] = (
+                iq[:, 0].astype(np.float32)
+                + 1j * iq[:, 1].astype(np.float32)
+            )
+
+    return result
+
+
+# ===================================================================
+# TerraSARReader
+# ===================================================================
+
+class TerraSARReader(ImageReader):
+    """Read TerraSAR-X / TanDEM-X SAR products.
+
+    Handles SSC products (COSAR binary, complex data) and detected
+    products (MGD, GEC, EEC via GeoTIFF).  Each instance opens one
+    polarization channel from the product directory.
+
+    Parameters
+    ----------
+    filepath : str or Path
+        Path to the product directory, main annotation XML, or a
+        data file within the product tree.
+    polarization : str
+        Polarization to open (``'HH'``, ``'VV'``, ``'HV'``, ``'VH'``).
+        Default ``'HH'``.
+
+    Attributes
+    ----------
+    metadata : TerraSARMetadata
+        Complete typed metadata with all annotation, geolocation,
+        and calibration sections.
+
+    Raises
+    ------
+    ImportError
+        If rasterio is not installed and the product is a detected
+        (GeoTIFF) type.
+    FileNotFoundError
+        If the product directory does not exist.
+    ValueError
+        If the product structure is invalid or the requested
+        polarization is not available.
+
+    Examples
+    --------
+    >>> from grdl.IO.sar import TerraSARReader
+    >>> with TerraSARReader('TSX1_SAR__SSC.../') as reader:
+    ...     chip = reader.read_chip(0, 1000, 0, 1000)
+    ...     print(reader.metadata.product_info.imaging_mode)
+    """
+
+    def __init__(
+        self,
+        filepath: Union[str, Path],
+        polarization: str = 'HH',
+    ) -> None:
+        self._requested_polarization = polarization.upper()
+
+        # Resolve product directory and main XML
+        self._product_dir, self._main_xml_path = (
+            _resolve_tsx_product_dir(Path(filepath))
+        )
+
+        # Pre-parse main XML to determine product type
+        try:
+            tree = ET.parse(str(self._main_xml_path))
+            self._xmltree = _strip_namespace(tree.getroot())
+        except ET.ParseError as e:
+            raise ValueError(
+                f"Failed to parse annotation XML: {e}"
+            ) from e
+
+        data_format = _xml_text(
+            self._xmltree, 'productInfo/imageDataInfo/imageDataFormat'
+        )
+        self._is_cosar = (
+            data_format is not None
+            and data_format.upper() == 'COSAR'
+        )
+
+        if not self._is_cosar and not _HAS_RASTERIO:
+            raise ImportError(
+                "Reading TerraSAR-X detected products (GeoTIFF) requires "
+                "rasterio. Install with: "
+                "conda install -c conda-forge rasterio"
+            )
+
+        # Locate image data file for requested polarization
+        imagedata_dir = self._product_dir / 'IMAGEDATA'
+        if not imagedata_dir.is_dir():
+            raise ValueError(
+                f"Missing IMAGEDATA directory: {imagedata_dir}"
+            )
+
+        self._image_file = self._find_image_file(
+            imagedata_dir, self._requested_polarization,
+        )
+        if self._image_file is None:
+            raise ValueError(
+                f"No image data file found for polarization "
+                f"'{self._requested_polarization}' in {imagedata_dir}"
+            )
+
+        # Locate optional annotation files
+        ann_dir = self._product_dir / 'ANNOTATION'
+        self._georef_path: Optional[Path] = None
+        self._caldata_path: Optional[Path] = None
+
+        if ann_dir.is_dir():
+            for name in ('GEOREF.xml', 'georef.xml'):
+                candidate = ann_dir / name
+                if candidate.exists():
+                    self._georef_path = candidate
+                    break
+
+            cal_dir = ann_dir / 'CALIBRATION'
+            if not cal_dir.is_dir():
+                cal_dir = ann_dir / 'calibration'
+            if cal_dir.is_dir():
+                for name in ('CALDATA.xml', 'caldata.xml'):
+                    candidate = cal_dir / name
+                    if candidate.exists():
+                        self._caldata_path = candidate
+                        break
+
+        # Read COSAR header if applicable
+        self._cosar_header: Optional[_COSARHeader] = None
+        self._rasterio_dataset = None
+
+        if self._is_cosar:
+            self._cosar_header = _read_cosar_header(self._image_file)
+
+        # Initialize base (validates path, calls _load_metadata)
+        super().__init__(self._product_dir)
+
+    @staticmethod
+    def _find_image_file(
+        imagedata_dir: Path,
+        polarization: str,
+    ) -> Optional[Path]:
+        """Find image data file for a given polarization.
+
+        Searches IMAGEDATA/ for ``.cos`` (COSAR) or ``.tif``
+        (GeoTIFF) files whose names contain the polarization string.
+
+        Parameters
+        ----------
+        imagedata_dir : Path
+            IMAGEDATA directory.
+        polarization : str
+            Uppercase polarization (e.g., ``'HH'``).
+
+        Returns
+        -------
+        Path or None
+            Path to matching image file.
+        """
+        pol_upper = polarization.upper()
+        for f in sorted(imagedata_dir.iterdir()):
+            if not f.is_file():
+                continue
+            if f.suffix.lower() not in ('.cos', '.tif', '.tiff'):
+                continue
+            if pol_upper in f.name.upper():
+                return f
+        return None
+
+    def _load_metadata(self) -> None:
+        """Parse annotation, GEOREF, and calibration XMLs."""
+        try:
+            root = self._xmltree
+
+            product_info = _extract_product_info(root)
+            scene_info = _extract_scene_info(root)
+            image_info = _extract_image_info(root)
+            radar_params = _extract_radar_params(root)
+            orbit_vectors = _extract_orbit_state_vectors(root)
+            doppler_info = _extract_doppler_info(root)
+            processing_info = _extract_processing_info(root)
+
+            # Geolocation grid (from GEOREF.xml)
+            geo_grid: List[TSXGeoGridPoint] = []
+            if self._georef_path is not None:
+                geo_grid = _extract_geolocation_grid(self._georef_path)
+
+            # Calibration (from CALDATA.xml)
+            calibration: Optional[TSXCalibration] = None
+            if self._caldata_path is not None:
+                calibration = _extract_calibration(self._caldata_path)
+
+            # Determine rows/cols
+            if self._is_cosar and self._cosar_header is not None:
+                rows = self._cosar_header.azimuth_lines
+                cols = self._cosar_header.rsnb
+            else:
+                rows = image_info.num_rows
+                cols = image_info.num_cols
+
+            # Determine dtype
+            if self._is_cosar:
+                dtype_str = 'complex64'
+            else:
+                dtype_str = 'float32'
+
+            # Open rasterio dataset for detected products
+            if not self._is_cosar:
+                self._rasterio_dataset = rasterio.open(
+                    str(self._image_file)
+                )
+                # Cross-check dimensions; prefer TIFF as authoritative
+                tiff_rows = self._rasterio_dataset.height
+                tiff_cols = self._rasterio_dataset.width
+                if tiff_rows != rows or tiff_cols != cols:
+                    rows = tiff_rows
+                    cols = tiff_cols
+                # Use actual dtype from TIFF
+                dtype_str = str(self._rasterio_dataset.dtypes[0])
+
+            # Format string
+            product_type = product_info.product_type or 'Unknown'
+            format_str = f'TerraSAR-X_{product_type}'
+
+            self.metadata = TerraSARMetadata(
+                format=format_str,
+                rows=rows,
+                cols=cols,
+                dtype=dtype_str,
+                bands=1,
+                product_info=product_info,
+                scene_info=scene_info,
+                image_info=image_info,
+                radar_params=radar_params,
+                orbit_state_vectors=(
+                    orbit_vectors if orbit_vectors else None
+                ),
+                geolocation_grid=geo_grid if geo_grid else None,
+                calibration=calibration,
+                doppler_info=doppler_info,
+                processing_info=processing_info,
+            )
+
+        except ET.ParseError as e:
+            raise ValueError(
+                f"Failed to parse annotation XML: {e}"
+            ) from e
+
+    def read_chip(
+        self,
+        row_start: int,
+        row_end: int,
+        col_start: int,
+        col_end: int,
+        bands: Optional[List[int]] = None,
+    ) -> np.ndarray:
+        """Read a spatial chip from the image data.
+
+        For SSC products, reads COSAR binary and returns complex64.
+        For detected products, reads GeoTIFF via rasterio.
+
+        Parameters
+        ----------
+        row_start : int
+            Starting row index (inclusive).
+        row_end : int
+            Ending row index (exclusive).
+        col_start : int
+            Starting column index (inclusive).
+        col_end : int
+            Ending column index (exclusive).
+        bands : Optional[List[int]]
+            Ignored for single-polarization products.
+
+        Returns
+        -------
+        np.ndarray
+            Image chip with shape ``(rows, cols)``.
+            dtype is ``complex64`` for SSC, format-dependent for
+            detected.
+
+        Raises
+        ------
+        ValueError
+            If indices are out of bounds.
+        """
+        if row_start < 0 or col_start < 0:
+            raise ValueError("Start indices must be non-negative")
+        if row_end > self.metadata.rows or col_end > self.metadata.cols:
+            raise ValueError(
+                f"End indices ({row_end}, {col_end}) exceed image "
+                f"dimensions ({self.metadata.rows}, {self.metadata.cols})"
+            )
+
+        if self._is_cosar:
+            return _read_cosar_chip(
+                self._image_file,
+                row_start, row_end, col_start, col_end,
+                self._cosar_header,
+            )
+        else:
+            window = Window(
+                col_start, row_start,
+                col_end - col_start, row_end - row_start,
+            )
+            data = self._rasterio_dataset.read(1, window=window)
+            return data
+
+    def get_available_polarizations(self) -> List[str]:
+        """Return polarizations available in the product.
+
+        Returns
+        -------
+        List[str]
+            E.g., ``['HH']`` or ``['HH', 'VV']``.
+        """
+        if (self.metadata.product_info is not None
+                and self.metadata.product_info.polarization_list
+                is not None):
+            return list(self.metadata.product_info.polarization_list)
+        return [self._requested_polarization]
+
+    def get_shape(self) -> Tuple[int, int]:
+        """Get image dimensions.
+
+        Returns
+        -------
+        Tuple[int, int]
+            ``(rows, cols)`` — total lines and samples.
+        """
+        return (self.metadata.rows, self.metadata.cols)
+
+    def get_dtype(self) -> np.dtype:
+        """Get data type.
+
+        Returns
+        -------
+        np.dtype
+            ``complex64`` for SSC, format-dependent for detected.
+        """
+        return np.dtype(self.metadata.dtype)
+
+    def close(self) -> None:
+        """Close resources."""
+        if self._rasterio_dataset is not None:
+            self._rasterio_dataset.close()
+            self._rasterio_dataset = None
+
+
+# ===================================================================
+# Convenience function
+# ===================================================================
+
+def open_terrasar(
+    filepath: Union[str, Path],
+    polarization: str = 'HH',
+) -> TerraSARReader:
+    """Open a TerraSAR-X / TanDEM-X product.
+
+    Factory function that validates the product structure and
+    returns a ``TerraSARReader``.
+
+    Parameters
+    ----------
+    filepath : str or Path
+        Path to the product directory or main annotation XML.
+    polarization : str
+        Polarization to open. Default ``'HH'``.
+
+    Returns
+    -------
+    TerraSARReader
+        Reader instance.
+
+    Examples
+    --------
+    >>> from grdl.IO.sar import open_terrasar
+    >>> reader = open_terrasar('TSX1_SAR__SSC.../', polarization='HH')
+    >>> chip = reader.read_chip(0, 512, 0, 512)
+    >>> reader.close()
+    """
+    return TerraSARReader(filepath, polarization=polarization)

--- a/tests/test_io_terrasar.py
+++ b/tests/test_io_terrasar.py
@@ -1,0 +1,958 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for TerraSAR-X / TanDEM-X reader and metadata.
+
+All tests use synthetic data -- no real TSX/TDX products required.
+
+Author
+------
+Jason Fritz
+jpfritz@zai.com
+
+License
+-------
+MIT License
+Copyright (c) 2024 geoint.org
+See LICENSE file for full text.
+
+Created
+-------
+2026-02-19
+
+Modified
+--------
+2026-02-19
+"""
+
+# Standard library
+import struct
+import textwrap
+from pathlib import Path
+
+# Third-party
+import numpy as np
+import pytest
+
+try:
+    import rasterio
+    from rasterio.transform import from_bounds
+    _HAS_RASTERIO = True
+except ImportError:
+    _HAS_RASTERIO = False
+
+# GRDL
+from grdl.IO.models.terrasar import (
+    TerraSARMetadata,
+    TSXProductInfo,
+    TSXSceneInfo,
+    TSXImageInfo,
+    TSXRadarParams,
+    TSXOrbitStateVector,
+    TSXGeoGridPoint,
+    TSXCalibration,
+    TSXDopplerInfo,
+    TSXProcessingInfo,
+)
+from grdl.IO.models.common import XYZ, LatLonHAE
+
+
+# ===================================================================
+# Synthetic product constants
+# ===================================================================
+
+_NUM_ROWS = 32
+_NUM_COLS = 48
+_SAMPLE_SIZE = 2  # int16
+_ANNOTATION_SIZE_PER_LINE = 8  # bytes of per-line annotation
+_RTNB = _ANNOTATION_SIZE_PER_LINE + _NUM_COLS * 2 * _SAMPLE_SIZE
+_HEADER_LINES = 4  # standard COSAR header occupies 4 range lines
+_TNL = _HEADER_LINES + _NUM_ROWS
+
+
+# ===================================================================
+# Synthetic XML builders
+# ===================================================================
+
+def _build_main_annotation_xml(
+    product_type: str = 'SSC',
+    data_format: str = 'COSAR',
+) -> str:
+    """Build a minimal TerraSAR-X annotation XML string."""
+    sample_type = 'COMPLEX' if product_type == 'SSC' else 'DETECTED'
+    projection = 'SLANTRANGE' if product_type == 'SSC' else 'MAP'
+
+    return textwrap.dedent(f"""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <level1Product>
+      <generalHeader>
+        <mission>TerraSAR-X</mission>
+        <satellite>TSX-1</satellite>
+        <generationTime>2026-02-19T10:00:00.000000Z</generationTime>
+      </generalHeader>
+      <productInfo>
+        <productVariantInfo>
+          <productType>{product_type}</productType>
+        </productVariantInfo>
+        <acquisitionInfo>
+          <imagingMode>SM</imagingMode>
+          <lookDirection>RIGHT</lookDirection>
+          <polarisationMode>SINGLE</polarisationMode>
+          <polarisationList>
+            <polLayer>HH</polLayer>
+          </polarisationList>
+        </acquisitionInfo>
+        <missionInfo>
+          <orbitDirection>ASCENDING</orbitDirection>
+          <absOrbit>12345</absOrbit>
+        </missionInfo>
+        <sceneInfo>
+          <start>
+            <timeUTC>2026-02-19T06:12:30.123456Z</timeUTC>
+          </start>
+          <stop>
+            <timeUTC>2026-02-19T06:12:32.654321Z</timeUTC>
+          </stop>
+          <sceneCenterCoord>
+            <lat>48.15</lat>
+            <lon>11.58</lon>
+            <incidenceAngle>35.5</incidenceAngle>
+          </sceneCenterCoord>
+          <sceneCornerCoord>
+            <lat>48.10</lat><lon>11.50</lon><height>500.0</height>
+          </sceneCornerCoord>
+          <sceneCornerCoord>
+            <lat>48.10</lat><lon>11.66</lon><height>500.0</height>
+          </sceneCornerCoord>
+          <sceneCornerCoord>
+            <lat>48.20</lat><lon>11.66</lon><height>500.0</height>
+          </sceneCornerCoord>
+          <sceneCornerCoord>
+            <lat>48.20</lat><lon>11.50</lon><height>500.0</height>
+          </sceneCornerCoord>
+          <rangeNearIncidenceAngle>33.0</rangeNearIncidenceAngle>
+          <rangeFarIncidenceAngle>38.0</rangeFarIncidenceAngle>
+          <headingAngle>350.5</headingAngle>
+        </sceneInfo>
+        <imageDataInfo>
+          <imageDataType>{sample_type}</imageDataType>
+          <imageDataFormat>{data_format}</imageDataFormat>
+          <imageRaster>
+            <numberOfRows>{_NUM_ROWS}</numberOfRows>
+            <numberOfColumns>{_NUM_COLS}</numberOfColumns>
+            <rowSpacing>1.8</rowSpacing>
+            <columnSpacing>0.9</columnSpacing>
+            <bitsPerSample>16</bitsPerSample>
+          </imageRaster>
+        </imageDataInfo>
+      </productInfo>
+      <productSpecific>
+        <complexImageInfo>
+          <commonPRF>3800.0</commonPRF>
+          <projection>{projection}</projection>
+        </complexImageInfo>
+      </productSpecific>
+      <instrument>
+        <radarParameters>
+          <centerFrequency>9.65e+09</centerFrequency>
+          <totalBandwidth>150000000.0</totalBandwidth>
+          <chirpDuration>3.72e-05</chirpDuration>
+          <adcSamplingRate>164800000.0</adcSamplingRate>
+        </radarParameters>
+      </instrument>
+      <platform>
+        <orbit>
+          <stateVec>
+            <timeUTC>2026-02-19T06:12:28.000000Z</timeUTC>
+            <posX>4164056.4</posX><posY>5282058.8</posY><posZ>2191522.7</posZ>
+            <velX>-162.8</velX><velY>-2812.7</velY><velZ>7055.8</velZ>
+          </stateVec>
+          <stateVec>
+            <timeUTC>2026-02-19T06:12:38.000000Z</timeUTC>
+            <posX>4162173.4</posX><posY>5253637.2</posY><posZ>2262000.0</posZ>
+            <velX>-200.0</velX><velY>-2900.0</velY><velZ>7000.0</velZ>
+          </stateVec>
+          <stateVec>
+            <timeUTC>2026-02-19T06:12:48.000000Z</timeUTC>
+            <posX>4160000.0</posX><posY>5225000.0</posY><posZ>2332000.0</posZ>
+            <velX>-230.0</velX><velY>-2950.0</velY><velZ>6950.0</velZ>
+          </stateVec>
+        </orbit>
+      </platform>
+      <processing>
+        <doppler>
+          <dopplerCentroid>
+            <referenceTime>5.33e-03</referenceTime>
+            <dopplerCentroidPolynomial>10.5 -200.0 50000.0</dopplerCentroidPolynomial>
+          </dopplerCentroid>
+        </doppler>
+        <processingInfo>
+          <processorVersion>4.12</processorVersion>
+          <processingLevel>L1B</processingLevel>
+          <rangeLooks>1</rangeLooks>
+          <azimuthLooks>1</azimuthLooks>
+        </processingInfo>
+      </processing>
+    </level1Product>
+    """).lstrip()
+
+
+def _build_georef_xml() -> str:
+    """Build a minimal GEOREF.xml with 4 corner tie points."""
+    return textwrap.dedent(f"""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <geoReference>
+      <geolocationGrid>
+        <gridPoint>
+          <lin>0</lin><pix>0</pix>
+          <lat>48.10</lat><lon>11.50</lon>
+          <height>500.0</height>
+          <incidenceAngle>33.0</incidenceAngle>
+        </gridPoint>
+        <gridPoint>
+          <lin>0</lin><pix>{_NUM_COLS - 1}</pix>
+          <lat>48.10</lat><lon>11.66</lon>
+          <height>500.0</height>
+          <incidenceAngle>35.0</incidenceAngle>
+        </gridPoint>
+        <gridPoint>
+          <lin>{_NUM_ROWS - 1}</lin><pix>0</pix>
+          <lat>48.20</lat><lon>11.50</lon>
+          <height>500.0</height>
+          <incidenceAngle>34.0</incidenceAngle>
+        </gridPoint>
+        <gridPoint>
+          <lin>{_NUM_ROWS - 1}</lin><pix>{_NUM_COLS - 1}</pix>
+          <lat>48.20</lat><lon>11.66</lon>
+          <height>500.0</height>
+          <incidenceAngle>38.0</incidenceAngle>
+        </gridPoint>
+      </geolocationGrid>
+    </geoReference>
+    """).lstrip()
+
+
+def _build_caldata_xml() -> str:
+    """Build a minimal CALDATA.xml with a calibration constant."""
+    return textwrap.dedent("""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <calibration>
+      <calibrationConstant>
+        <calFactor>3.56e+04</calFactor>
+      </calibrationConstant>
+      <noiseEquivalentBetaNought>-25.3</noiseEquivalentBetaNought>
+      <calibrationType>CALIBRATED</calibrationType>
+    </calibration>
+    """).lstrip()
+
+
+def _build_cosar_binary(
+    num_rows: int = _NUM_ROWS,
+    num_cols: int = _NUM_COLS,
+    sample_size: int = _SAMPLE_SIZE,
+    annotation_size: int = _ANNOTATION_SIZE_PER_LINE,
+) -> bytes:
+    """Build a synthetic COSAR binary file.
+
+    COSAR format: big-endian, 32-byte burst header (8 x uint32),
+    then ``header_lines`` padding lines, then ``num_rows`` data lines.
+    Each data line has ``annotation_size`` bytes of padding followed by
+    ``num_cols`` interleaved int16 I/Q pairs.  I values are set to
+    the column index, Q values to the row index, for easy verification.
+
+    Parameters
+    ----------
+    num_rows : int
+        Number of azimuth lines (data lines).
+    num_cols : int
+        Number of range samples per line.
+    sample_size : int
+        Bytes per sample component (2 for int16).
+    annotation_size : int
+        Padding bytes per data line before sample data.
+
+    Returns
+    -------
+    bytes
+        Complete COSAR binary content.
+    """
+    rtnb = annotation_size + num_cols * 2 * sample_size
+    header_lines = _HEADER_LINES
+    tnl = header_lines + num_rows
+    bib = tnl * rtnb
+
+    # Burst header: 8 x uint32 big-endian
+    # BIB, RSRI, RSNB, AS, BI, RTNB, TNL, "CSAR"
+    header = struct.pack(
+        '>7I4s',
+        bib,              # BIB
+        0,                # RSRI
+        num_cols,         # RSNB
+        num_rows,         # AS
+        1,                # BI
+        rtnb,             # RTNB
+        tnl,              # TNL
+        b'CSAR',          # magic
+    )
+
+    # Pad burst header to fill header_lines * rtnb bytes
+    header_pad = b'\x00' * (header_lines * rtnb - len(header))
+
+    # Data lines (big-endian int16 I/Q)
+    lines = []
+    for row in range(num_rows):
+        annotation = b'\x00' * annotation_size
+
+        iq = np.empty((num_cols, 2), dtype='>i2')  # big-endian
+        iq[:, 0] = np.arange(num_cols, dtype=np.int16)  # I = col
+        iq[:, 1] = np.full(num_cols, row, dtype=np.int16)  # Q = row
+
+        lines.append(annotation + iq.tobytes())
+
+    return header + header_pad + b''.join(lines)
+
+
+# ===================================================================
+# Fixtures
+# ===================================================================
+
+@pytest.fixture
+def synthetic_tsx_ssc(tmp_path):
+    """Create a synthetic TerraSAR-X SSC product directory.
+
+    Yields the path to the product directory.
+    """
+    product_dir = tmp_path / 'TSX1_SAR__SSC______SM_S_SRA_20260219_TEST'
+    product_dir.mkdir()
+
+    # Main annotation XML (name matches directory)
+    xml_name = product_dir.name + '.xml'
+    (product_dir / xml_name).write_text(
+        _build_main_annotation_xml(
+            product_type='SSC', data_format='COSAR',
+        )
+    )
+
+    # IMAGEDATA/
+    imagedata_dir = product_dir / 'IMAGEDATA'
+    imagedata_dir.mkdir()
+    cos_name = 'IMAGE_HH_SRA_strip_001.cos'
+    (imagedata_dir / cos_name).write_bytes(
+        _build_cosar_binary()
+    )
+
+    # ANNOTATION/
+    ann_dir = product_dir / 'ANNOTATION'
+    ann_dir.mkdir()
+    (ann_dir / 'GEOREF.xml').write_text(_build_georef_xml())
+
+    cal_dir = ann_dir / 'CALIBRATION'
+    cal_dir.mkdir()
+    (cal_dir / 'CALDATA.xml').write_text(_build_caldata_xml())
+
+    yield product_dir
+
+
+@pytest.fixture
+def synthetic_tsx_mgd(tmp_path):
+    """Create a synthetic TerraSAR-X MGD product directory.
+
+    Requires rasterio.  Yields the path to the product directory.
+    """
+    if not _HAS_RASTERIO:
+        pytest.skip("rasterio required for TerraSAR-X MGD tests")
+
+    product_dir = tmp_path / 'TSX1_SAR__MGD______SM_D_SRA_20260219_TEST'
+    product_dir.mkdir()
+
+    xml_name = product_dir.name + '.xml'
+    (product_dir / xml_name).write_text(
+        _build_main_annotation_xml(
+            product_type='MGD', data_format='GEOTIFF',
+        )
+    )
+
+    imagedata_dir = product_dir / 'IMAGEDATA'
+    imagedata_dir.mkdir()
+    tiff_path = imagedata_dir / 'IMAGE_HH_SRA_strip_001.tif'
+
+    rng = np.random.default_rng(42)
+    data = rng.random((_NUM_ROWS, _NUM_COLS)).astype(np.float32) * 1000
+
+    with rasterio.open(
+        str(tiff_path), 'w', driver='GTiff',
+        height=_NUM_ROWS, width=_NUM_COLS,
+        count=1, dtype='float32',
+    ) as dst:
+        dst.write(data, 1)
+
+    ann_dir = product_dir / 'ANNOTATION'
+    ann_dir.mkdir()
+    (ann_dir / 'GEOREF.xml').write_text(_build_georef_xml())
+    cal_dir = ann_dir / 'CALIBRATION'
+    cal_dir.mkdir()
+    (cal_dir / 'CALDATA.xml').write_text(_build_caldata_xml())
+
+    yield product_dir
+
+
+# ===================================================================
+# Metadata dataclass tests
+# ===================================================================
+
+class TestTerraSARMetadata:
+    """Test metadata dataclass construction and access."""
+
+    def test_basic_construction(self):
+        """TerraSARMetadata can be constructed with required fields."""
+        meta = TerraSARMetadata(
+            format='TerraSAR-X_SSC',
+            rows=100,
+            cols=200,
+            dtype='complex64',
+        )
+        assert meta.rows == 100
+        assert meta.cols == 200
+        assert meta.format == 'TerraSAR-X_SSC'
+
+    def test_dict_like_access(self):
+        """Metadata supports dict-like access."""
+        meta = TerraSARMetadata(
+            format='TerraSAR-X_SSC',
+            rows=100,
+            cols=200,
+            dtype='complex64',
+        )
+        assert meta['rows'] == 100
+        assert meta['format'] == 'TerraSAR-X_SSC'
+
+    def test_product_info(self):
+        """TSXProductInfo fields are accessible."""
+        info = TSXProductInfo(
+            mission='TerraSAR-X',
+            satellite='TSX-1',
+            product_type='SSC',
+            imaging_mode='SM',
+            absolute_orbit=12345,
+        )
+        assert info.satellite == 'TSX-1'
+        assert info.absolute_orbit == 12345
+
+    def test_scene_info(self):
+        """TSXSceneInfo fields are accessible."""
+        si = TSXSceneInfo(
+            center_lat=48.15,
+            center_lon=11.58,
+            incidence_angle_near=33.0,
+            incidence_angle_far=38.0,
+        )
+        assert si.center_lat == pytest.approx(48.15)
+        assert si.incidence_angle_near == pytest.approx(33.0)
+
+    def test_image_info(self):
+        """TSXImageInfo fields are accessible."""
+        ii = TSXImageInfo(
+            num_rows=1000,
+            num_cols=2000,
+            row_spacing=1.8,
+            col_spacing=0.9,
+            sample_type='COMPLEX',
+            data_format='COSAR',
+        )
+        assert ii.num_rows == 1000
+        assert ii.data_format == 'COSAR'
+
+    def test_radar_params(self):
+        """TSXRadarParams fields are accessible."""
+        rp = TSXRadarParams(
+            center_frequency=9.65e9,
+            prf=3800.0,
+            range_bandwidth=150e6,
+        )
+        assert rp.center_frequency == pytest.approx(9.65e9)
+        assert rp.prf == pytest.approx(3800.0)
+
+    def test_orbit_state_vector(self):
+        """TSXOrbitStateVector stores position and velocity."""
+        osv = TSXOrbitStateVector(
+            time_utc='2026-02-19T06:12:28.000000Z',
+            position=XYZ(x=4164056.4, y=5282058.8, z=2191522.7),
+            velocity=XYZ(x=-162.8, y=-2812.7, z=7055.8),
+        )
+        assert osv.position.x == pytest.approx(4164056.4)
+
+    def test_geo_grid_point(self):
+        """TSXGeoGridPoint stores coordinates."""
+        pt = TSXGeoGridPoint(
+            line=0.0, pixel=0.0,
+            latitude=48.10, longitude=11.50, height=500.0,
+        )
+        assert pt.latitude == pytest.approx(48.10)
+        assert pt.longitude == pytest.approx(11.50)
+
+    def test_calibration(self):
+        """TSXCalibration stores calibration constant."""
+        cal = TSXCalibration(
+            calibration_constant=3.56e4,
+            noise_equivalent_beta_nought=-25.3,
+        )
+        assert cal.calibration_constant == pytest.approx(3.56e4)
+
+    def test_doppler_info(self):
+        """TSXDopplerInfo stores polynomial coefficients."""
+        di = TSXDopplerInfo(
+            doppler_centroid_coefficients=np.array(
+                [10.5, -200.0, 50000.0]
+            ),
+            reference_time=5.33e-3,
+        )
+        assert di.doppler_centroid_coefficients.shape == (3,)
+
+    def test_processing_info(self):
+        """TSXProcessingInfo stores processor parameters."""
+        pi = TSXProcessingInfo(
+            processor_version='4.12',
+            range_looks=1,
+            azimuth_looks=1,
+        )
+        assert pi.processor_version == '4.12'
+
+    def test_full_metadata_with_all_sections(self):
+        """TerraSARMetadata with all sections populated."""
+        meta = TerraSARMetadata(
+            format='TerraSAR-X_SSC',
+            rows=100, cols=200, dtype='complex64',
+            product_info=TSXProductInfo(satellite='TSX-1'),
+            scene_info=TSXSceneInfo(center_lat=48.15),
+            image_info=TSXImageInfo(num_rows=100, num_cols=200),
+            radar_params=TSXRadarParams(center_frequency=9.65e9),
+            orbit_state_vectors=[TSXOrbitStateVector(time_utc='t0')],
+            geolocation_grid=[TSXGeoGridPoint(latitude=48.10)],
+            calibration=TSXCalibration(calibration_constant=3.56e4),
+            doppler_info=TSXDopplerInfo(reference_time=5.33e-3),
+            processing_info=TSXProcessingInfo(processor_version='4.12'),
+        )
+        assert meta.product_info.satellite == 'TSX-1'
+        assert len(meta.orbit_state_vectors) == 1
+        assert meta.calibration.calibration_constant == pytest.approx(
+            3.56e4
+        )
+
+
+# ===================================================================
+# COSAR binary reading tests
+# ===================================================================
+
+class TestCOSARBinaryReading:
+    """Test low-level COSAR parsing functions."""
+
+    def test_read_cosar_header(self, tmp_path):
+        """Verify header extraction from synthetic COSAR binary."""
+        from grdl.IO.sar.terrasar import _read_cosar_header
+
+        cos_path = tmp_path / 'test.cos'
+        cos_path.write_bytes(_build_cosar_binary())
+
+        hdr = _read_cosar_header(cos_path)
+        assert hdr.rsnb == _NUM_COLS
+        assert hdr.azimuth_lines == _NUM_ROWS
+        assert hdr.rtnb == _RTNB
+        assert hdr.tnl == _TNL
+        assert hdr.header_lines == _HEADER_LINES
+        assert hdr.sample_size == _SAMPLE_SIZE
+
+    def test_read_cosar_chip_known_values(self, tmp_path):
+        """Read known I/Q values and verify complex conversion."""
+        from grdl.IO.sar.terrasar import (
+            _read_cosar_header, _read_cosar_chip,
+        )
+
+        cos_path = tmp_path / 'test.cos'
+        cos_path.write_bytes(_build_cosar_binary())
+
+        hdr = _read_cosar_header(cos_path)
+        chip = _read_cosar_chip(cos_path, 0, 4, 0, 6, hdr)
+
+        assert chip.shape == (4, 6)
+        assert chip.dtype == np.complex64
+
+        # I = col_index, Q = row_index
+        # chip[row=2, col=3] should be (3 + 2j)
+        assert chip[2, 3] == pytest.approx(3 + 2j)
+        assert chip[0, 0] == pytest.approx(0 + 0j)
+        assert chip[1, 5] == pytest.approx(5 + 1j)
+
+    def test_read_cosar_chip_subsection(self, tmp_path):
+        """Read a sub-chip from the middle of the image."""
+        from grdl.IO.sar.terrasar import (
+            _read_cosar_header, _read_cosar_chip,
+        )
+
+        cos_path = tmp_path / 'test.cos'
+        cos_path.write_bytes(_build_cosar_binary())
+
+        hdr = _read_cosar_header(cos_path)
+        # Read rows 10-14, cols 20-25
+        chip = _read_cosar_chip(cos_path, 10, 14, 20, 25, hdr)
+
+        assert chip.shape == (4, 5)
+        # chip[0, 0] → row=10, col=20 → I=20, Q=10
+        assert chip[0, 0] == pytest.approx(20 + 10j)
+        # chip[3, 4] → row=13, col=24 → I=24, Q=13
+        assert chip[3, 4] == pytest.approx(24 + 13j)
+
+    def test_read_cosar_full_image(self, tmp_path):
+        """Read entire COSAR image."""
+        from grdl.IO.sar.terrasar import (
+            _read_cosar_header, _read_cosar_chip,
+        )
+
+        cos_path = tmp_path / 'test.cos'
+        cos_path.write_bytes(_build_cosar_binary())
+
+        hdr = _read_cosar_header(cos_path)
+        full = _read_cosar_chip(
+            cos_path, 0, hdr.azimuth_lines, 0, hdr.rsnb, hdr,
+        )
+
+        assert full.shape == (_NUM_ROWS, _NUM_COLS)
+        assert full.dtype == np.complex64
+
+    def test_invalid_cosar_header(self, tmp_path):
+        """ValueError for truncated COSAR file."""
+        from grdl.IO.sar.terrasar import _read_cosar_header
+
+        cos_path = tmp_path / 'truncated.cos'
+        cos_path.write_bytes(b'\x00' * 8)  # Too short
+
+        with pytest.raises(ValueError, match="too small"):
+            _read_cosar_header(cos_path)
+
+    def test_invalid_cosar_magic(self, tmp_path):
+        """ValueError for wrong COSAR magic bytes."""
+        from grdl.IO.sar.terrasar import _read_cosar_header
+
+        # Build 32 bytes with wrong magic
+        bad_header = struct.pack(
+            '>7I4s',
+            1000, 0, 10, 10, 1, 100, 14, b'XXXX',
+        )
+        cos_path = tmp_path / 'bad_magic.cos'
+        cos_path.write_bytes(bad_header)
+
+        with pytest.raises(ValueError, match="magic"):
+            _read_cosar_header(cos_path)
+
+
+# ===================================================================
+# SSC reader tests
+# ===================================================================
+
+class TestTerraSARSSCReader:
+    """Test reader with synthetic SSC (COSAR) data."""
+
+    def test_reader_loads(self, synthetic_tsx_ssc):
+        """Reader opens synthetic product and populates metadata."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_ssc) as reader:
+            meta = reader.metadata
+            assert meta.format == 'TerraSAR-X_SSC'
+            assert meta.rows == _NUM_ROWS
+            assert meta.cols == _NUM_COLS
+            assert meta.dtype == 'complex64'
+
+    def test_product_info_parsed(self, synthetic_tsx_ssc):
+        """Product info is extracted from main annotation."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_ssc) as reader:
+            pi = reader.metadata.product_info
+            assert pi.mission == 'TerraSAR-X'
+            assert pi.satellite == 'TSX-1'
+            assert pi.product_type == 'SSC'
+            assert pi.imaging_mode == 'SM'
+            assert pi.look_direction == 'RIGHT'
+            assert pi.orbit_direction == 'ASCENDING'
+            assert pi.absolute_orbit == 12345
+
+    def test_scene_info_parsed(self, synthetic_tsx_ssc):
+        """Scene info is extracted from main annotation."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_ssc) as reader:
+            si = reader.metadata.scene_info
+            assert si.center_lat == pytest.approx(48.15)
+            assert si.center_lon == pytest.approx(11.58)
+            assert si.incidence_angle_near == pytest.approx(33.0)
+            assert si.incidence_angle_far == pytest.approx(38.0)
+            assert si.heading_angle == pytest.approx(350.5)
+
+    def test_scene_corners_parsed(self, synthetic_tsx_ssc):
+        """Scene corner coordinates are extracted."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_ssc) as reader:
+            corners = reader.metadata.scene_info.scene_extent
+            assert corners is not None
+            assert len(corners) == 4
+            assert corners[0].lat == pytest.approx(48.10)
+            assert corners[0].lon == pytest.approx(11.50)
+
+    def test_image_info_parsed(self, synthetic_tsx_ssc):
+        """Image info is extracted."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_ssc) as reader:
+            ii = reader.metadata.image_info
+            assert ii.sample_type == 'COMPLEX'
+            assert ii.data_format == 'COSAR'
+            assert ii.row_spacing == pytest.approx(1.8)
+            assert ii.col_spacing == pytest.approx(0.9)
+
+    def test_radar_params_parsed(self, synthetic_tsx_ssc):
+        """Radar parameters are extracted."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_ssc) as reader:
+            rp = reader.metadata.radar_params
+            assert rp.center_frequency == pytest.approx(9.65e9)
+            assert rp.prf == pytest.approx(3800.0)
+            assert rp.range_bandwidth == pytest.approx(150e6)
+
+    def test_orbit_parsed(self, synthetic_tsx_ssc):
+        """Orbit state vectors are extracted."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_ssc) as reader:
+            osvs = reader.metadata.orbit_state_vectors
+            assert len(osvs) == 3
+            assert osvs[0].position.x == pytest.approx(4164056.4)
+            assert osvs[0].velocity.z == pytest.approx(7055.8)
+
+    def test_geolocation_grid_parsed(self, synthetic_tsx_ssc):
+        """Geolocation grid points are extracted from GEOREF.xml."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_ssc) as reader:
+            grid = reader.metadata.geolocation_grid
+            assert len(grid) == 4
+            assert grid[0].latitude == pytest.approx(48.10)
+            assert grid[0].longitude == pytest.approx(11.50)
+            assert grid[0].incidence_angle == pytest.approx(33.0)
+
+    def test_calibration_parsed(self, synthetic_tsx_ssc):
+        """Calibration is extracted from CALDATA.xml."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_ssc) as reader:
+            cal = reader.metadata.calibration
+            assert cal is not None
+            assert cal.calibration_constant == pytest.approx(3.56e4)
+            assert cal.noise_equivalent_beta_nought == pytest.approx(
+                -25.3
+            )
+
+    def test_doppler_info_parsed(self, synthetic_tsx_ssc):
+        """Doppler centroid is extracted."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_ssc) as reader:
+            di = reader.metadata.doppler_info
+            assert di.reference_time == pytest.approx(5.33e-3)
+            assert di.doppler_centroid_coefficients is not None
+            assert di.doppler_centroid_coefficients.shape == (3,)
+
+    def test_processing_info_parsed(self, synthetic_tsx_ssc):
+        """Processing info is extracted."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_ssc) as reader:
+            pi = reader.metadata.processing_info
+            assert pi.processor_version == '4.12'
+            assert pi.range_looks == 1
+            assert pi.azimuth_looks == 1
+
+    def test_read_chip(self, synthetic_tsx_ssc):
+        """read_chip returns complex64 data with correct shape."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_ssc) as reader:
+            chip = reader.read_chip(0, 10, 0, 15)
+            assert chip.shape == (10, 15)
+            assert chip.dtype == np.complex64
+            # Verify known values: I=col, Q=row
+            assert chip[2, 3] == pytest.approx(3 + 2j)
+
+    def test_read_chip_full(self, synthetic_tsx_ssc):
+        """read_chip can read entire image."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_ssc) as reader:
+            full = reader.read_chip(0, _NUM_ROWS, 0, _NUM_COLS)
+            assert full.shape == (_NUM_ROWS, _NUM_COLS)
+
+    def test_get_shape(self, synthetic_tsx_ssc):
+        """get_shape returns (rows, cols)."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_ssc) as reader:
+            assert reader.get_shape() == (_NUM_ROWS, _NUM_COLS)
+
+    def test_get_dtype(self, synthetic_tsx_ssc):
+        """get_dtype returns complex64 for SSC."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_ssc) as reader:
+            assert reader.get_dtype() == np.dtype('complex64')
+
+    def test_available_polarizations(self, synthetic_tsx_ssc):
+        """get_available_polarizations returns parsed list."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_ssc) as reader:
+            pols = reader.get_available_polarizations()
+            assert pols == ['HH']
+
+    def test_context_manager(self, synthetic_tsx_ssc):
+        """Context manager opens and closes cleanly."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        reader = TerraSARReader(synthetic_tsx_ssc)
+        assert reader.metadata.rows == _NUM_ROWS
+        reader.close()
+
+    def test_open_from_xml(self, synthetic_tsx_ssc):
+        """Reader can open from the main XML file path."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        xml_file = list(synthetic_tsx_ssc.glob('*.xml'))[0]
+        with TerraSARReader(xml_file) as reader:
+            assert reader.metadata.rows == _NUM_ROWS
+
+    def test_open_from_cosar(self, synthetic_tsx_ssc):
+        """Reader can open from a .cos file path."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        cos_file = list(
+            (synthetic_tsx_ssc / 'IMAGEDATA').glob('*.cos')
+        )[0]
+        with TerraSARReader(cos_file) as reader:
+            assert reader.metadata.rows == _NUM_ROWS
+
+
+# ===================================================================
+# MGD reader tests
+# ===================================================================
+
+@pytest.mark.skipif(not _HAS_RASTERIO,
+                    reason="rasterio required for TerraSAR-X MGD")
+class TestTerraSARMGDReader:
+    """Test reader with synthetic MGD (GeoTIFF) data."""
+
+    def test_reader_loads(self, synthetic_tsx_mgd):
+        """Reader opens synthetic MGD and populates metadata."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_mgd) as reader:
+            meta = reader.metadata
+            assert meta.format == 'TerraSAR-X_MGD'
+            assert meta.rows == _NUM_ROWS
+            assert meta.cols == _NUM_COLS
+
+    def test_product_type_detected(self, synthetic_tsx_mgd):
+        """Product type is MGD with DETECTED sample type."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_mgd) as reader:
+            pi = reader.metadata.product_info
+            assert pi.product_type == 'MGD'
+            ii = reader.metadata.image_info
+            assert ii.sample_type == 'DETECTED'
+            assert ii.data_format == 'GEOTIFF'
+
+    def test_read_chip(self, synthetic_tsx_mgd):
+        """read_chip returns float32 data with correct shape."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_mgd) as reader:
+            chip = reader.read_chip(0, 10, 0, 15)
+            assert chip.shape == (10, 15)
+            assert chip.dtype == np.float32
+            assert np.any(chip != 0)
+
+    def test_read_chip_full(self, synthetic_tsx_mgd):
+        """read_chip can read entire MGD image."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_mgd) as reader:
+            full = reader.read_chip(0, _NUM_ROWS, 0, _NUM_COLS)
+            assert full.shape == (_NUM_ROWS, _NUM_COLS)
+
+    def test_get_dtype(self, synthetic_tsx_mgd):
+        """get_dtype returns float32 for detected product."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_mgd) as reader:
+            assert reader.get_dtype() == np.dtype('float32')
+
+
+# ===================================================================
+# Error handling tests
+# ===================================================================
+
+class TestTerraSARReaderErrors:
+    """Test error conditions."""
+
+    def test_missing_directory(self, tmp_path):
+        """FileNotFoundError for non-existent path."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with pytest.raises((FileNotFoundError, ValueError)):
+            TerraSARReader(tmp_path / 'nonexistent_dir')
+
+    def test_invalid_product_no_xml(self, tmp_path):
+        """ValueError for directory without main XML."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        fake_dir = tmp_path / 'TSX1_SAR__SSC_fake'
+        fake_dir.mkdir()
+        with pytest.raises(ValueError, match="No TerraSAR-X"):
+            TerraSARReader(fake_dir)
+
+    def test_invalid_polarization(self, synthetic_tsx_ssc):
+        """ValueError for unavailable polarization."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with pytest.raises(ValueError, match="No image data file"):
+            TerraSARReader(synthetic_tsx_ssc, polarization='VV')
+
+    def test_chip_negative_indices(self, synthetic_tsx_ssc):
+        """ValueError for negative start indices."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_ssc) as reader:
+            with pytest.raises(ValueError, match="non-negative"):
+                reader.read_chip(-1, 10, 0, 10)
+
+    def test_chip_exceeds_dimensions(self, synthetic_tsx_ssc):
+        """ValueError for indices beyond image dimensions."""
+        from grdl.IO.sar.terrasar import TerraSARReader
+
+        with TerraSARReader(synthetic_tsx_ssc) as reader:
+            with pytest.raises(ValueError, match="exceed"):
+                reader.read_chip(0, _NUM_ROWS + 1, 0, 10)
+
+
+# ===================================================================
+# Convenience function tests
+# ===================================================================
+
+class TestOpenTerrasar:
+    """Test open_terrasar convenience function."""
+
+    def test_open_terrasar_ssc(self, synthetic_tsx_ssc):
+        """open_terrasar returns TerraSARReader."""
+        from grdl.IO.sar.terrasar import open_terrasar
+
+        with open_terrasar(synthetic_tsx_ssc) as reader:
+            assert reader.metadata.format == 'TerraSAR-X_SSC'


### PR DESCRIPTION
Implements TerraSARReader for SSC (complex COSAR) and detected (MGD/GEC/EEC GeoTIFF) products. Parses main XML annotation, GEOREF.xml geolocation grid, and CALDATA.xml calibration. COSAR reading uses pure numpy+struct (big-endian, 32-byte burst header with CSAR magic). Accepts product directory, annotation XML, or data file as entry point. Includes 48 tests with synthetic data.