### PR TITLE
Update to_rgb() output shape to channels-first (3, rows, cols)

### DIFF
--- a/grdl/image_processing/decomposition/dual_pol_halpha.py
+++ b/grdl/image_processing/decomposition/dual_pol_halpha.py
@@ -86,7 +86,7 @@ class DualPolHAlpha(ImageProcessor):
     >>> halpha = DualPolHAlpha(window_size=9)
     >>> components = halpha.decompose(s_vv, s_vh)
     >>> print(components['entropy'].shape)  # same as input
-    >>> rgb = halpha.to_rgb(components)     # (rows, cols, 3) float32
+    >>> rgb = halpha.to_rgb(components)     # (3, rows, cols) float32
     """
 
     window_size: Annotated[int, Range(min=3, max=31),
@@ -230,7 +230,7 @@ class DualPolHAlpha(ImageProcessor):
         Returns
         -------
         np.ndarray
-            RGB image, shape ``(rows, cols, 3)``, dtype float32,
+            RGB image, shape ``(3, rows, cols)``, dtype float32,
             values in [0, 1].
         """
         required = {'entropy', 'alpha', 'span'}
@@ -252,7 +252,7 @@ class DualPolHAlpha(ImageProcessor):
         # Blue: Alpha normalised to [0, 1] (0-90 degrees)
         b = np.clip(components['alpha'] / 90.0, 0.0, 1.0).astype(np.float32)
 
-        return np.dstack([r, g, b])
+        return np.stack([r, g, b], axis=0)
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/grdl/image_processing/decomposition/pauli.py
+++ b/grdl/image_processing/decomposition/pauli.py
@@ -207,7 +207,7 @@ class PauliDecomposition(PolarimetricDecomposition):
         Returns
         -------
         np.ndarray
-            RGB image, shape (rows, cols, 3), dtype float32,
+            RGB image, shape (3, rows, cols), dtype float32,
             values in [0, 1].
 
         Raises
@@ -247,7 +247,7 @@ class PauliDecomposition(PolarimetricDecomposition):
             real_components['surface'], percentile_low, percentile_high
         )
 
-        return np.dstack([r, g, b])
+        return np.stack([r, g, b], axis=0)
 
     def __repr__(self) -> str:
         return "PauliDecomposition()"

--- a/tests/test_image_processing_decomposition.py
+++ b/tests/test_image_processing_decomposition.py
@@ -395,7 +395,7 @@ class TestConversions:
         c = pauli.decompose(*quad_pol_random)
         rgb = pauli.to_rgb(c)
         rows, cols = quad_pol_random[0].shape
-        assert rgb.shape == (rows, cols, 3)
+        assert rgb.shape == (3, rows, cols)
 
     def test_to_rgb_range(self, pauli, quad_pol_random):
         c = pauli.decompose(*quad_pol_random)
@@ -412,7 +412,7 @@ class TestConversions:
         c = pauli.decompose(*quad_pol_random)
         for rep in ('db', 'magnitude', 'power'):
             rgb = pauli.to_rgb(c, representation=rep)
-            assert rgb.shape[2] == 3
+            assert rgb.shape[0] == 3
             assert np.all(rgb >= 0.0)
             assert np.all(rgb <= 1.0)
 

--- a/tests/test_image_processing_decomposition_dual_pol.py
+++ b/tests/test_image_processing_decomposition_dual_pol.py
@@ -249,7 +249,7 @@ class TestToRgb:
         s_co, s_cross = copol_only
         result = halpha.decompose(s_co, s_cross)
         rgb = halpha.to_rgb(result)
-        assert rgb.shape == (s_co.shape[0], s_co.shape[1], 3)
+        assert rgb.shape == (3, s_co.shape[0], s_co.shape[1])
 
     def test_output_dtype(self, halpha, copol_only):
         s_co, s_cross = copol_only


### PR DESCRIPTION
Both PauliDecomposition.to_rgb() and DualPolHAlpha.to_rgb() now return (3, rows, cols) instead of (rows, cols, 3) for consistency with the grdk viewer's channels-first convention. Updated corresponding test assertions.