### PR TITLE
Updates to allow a CPHD to SICD converter - currently just example

### DIFF
--- a/grdl/IO/sar/sicd_writer.py
+++ b/grdl/IO/sar/sicd_writer.py
@@ -26,7 +26,7 @@ Created
 
 Modified
 --------
-2026-03-10
+2026-05-15
 """
 
 from __future__ import annotations
@@ -136,7 +136,7 @@ def _sicd_metadata_to_sarpy(meta: SICDMetadata) -> 'SICDType':
             )
         sicd.CollectionInfo = CollectionInfoType(
             CollectorName=ci.collector_name,
-            CoreName=ci.core_name,
+            CoreName=(ci.core_name[:74] if ci.core_name else ci.core_name),
             RadarMode=radar_mode,
             Classification=ci.classification,
         )

--- a/grdl/example/IO/sar/view_sicd.py
+++ b/grdl/example/IO/sar/view_sicd.py
@@ -1,21 +1,17 @@
 # -*- coding: utf-8 -*-
 """
-SICD Viewer - Display complex SAR imagery from SICD files.
+SICD Viewer - Display complex SAR imagery from SICD files using grdk-viewer.
 
-Reads a SICD file and displays the magnitude image using matplotlib.
-Displays linear magnitude (not dB) with percentile contrast stretch.
-Shows metadata and geolocation information in the console.
+Reads a SICD file and displays the imagery in the interactive grdk-viewer
+application. Shows metadata and geolocation information in the console.
 
 Usage:
   python view_sicd.py <sicd_file>
-  python view_sicd.py <sicd_file> --cmap gray
-  python view_sicd.py <sicd_file> --plow 1 --phigh 99
   python view_sicd.py --help
 
 Dependencies
 ------------
-matplotlib
-sarkit or sarpy
+grdk
 
 Author
 ------
@@ -34,7 +30,7 @@ Created
 
 Modified
 --------
-2026-02-11
+2026-05-14
 """
 
 # Standard library
@@ -43,17 +39,13 @@ import sys
 from pathlib import Path
 
 # Third-party
-import numpy as np
-
-# Matplotlib -- set backend before importing pyplot
-import matplotlib
-matplotlib.use("QtAgg")
-import matplotlib.pyplot as plt  # noqa: E402
+from grdk.viewers import show
 
 # GRDL
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from grdl.IO import SICDReader
+from grdl.geolocation import create_geolocation
 
 
 def parse_args() -> argparse.Namespace:
@@ -65,7 +57,7 @@ def parse_args() -> argparse.Namespace:
         Parsed arguments.
     """
     parser = argparse.ArgumentParser(
-        description="Display SICD complex SAR imagery (linear magnitude).",
+        description="Display SICD complex SAR imagery in the grdk-viewer.",
     )
     parser.add_argument(
         "filepath",
@@ -74,41 +66,16 @@ def parse_args() -> argparse.Namespace:
         default=Path('default/path/to/file'),
         help="Path to the SICD file (NITF or other SICD container).",
     )
-    parser.add_argument(
-        "--cmap",
-        type=str,
-        default="gray",
-        help="Matplotlib colormap (default: gray).",
-    )
-    parser.add_argument(
-        "--plow",
-        type=float,
-        default=2.0,
-        help="Lower percentile for contrast stretch (default: 2).",
-    )
-    parser.add_argument(
-        "--phigh",
-        type=float,
-        default=98.0,
-        help="Upper percentile for contrast stretch (default: 98).",
-    )
     return parser.parse_args()
 
 
-def view_sicd(filepath: Path, cmap: str = "gray",
-              plow: float = 2.0, phigh: float = 98.0) -> None:
-    """Read and display a SICD image.
+def view_sicd(filepath: Path) -> None:
+    """Read and display a SICD image in the grdk-viewer.
 
     Parameters
     ----------
     filepath : Path
         Path to the SICD file.
-    cmap : str
-        Matplotlib colormap name.
-    plow : float
-        Lower percentile for contrast stretch.
-    phigh : float
-        Upper percentile for contrast stretch.
     """
     print(f"Opening: {filepath}")
 
@@ -135,7 +102,6 @@ def view_sicd(filepath: Path, cmap: str = "gray",
             if tl.collect_duration is not None:
                 print(f"  Duration:       {tl.collect_duration:.3f} s")
 
-        # Print geolocation from metadata
         scp_llh = None
         if meta.geo_data is not None and meta.geo_data.scp is not None:
             scp_llh = meta.geo_data.scp.llh
@@ -143,11 +109,13 @@ def view_sicd(filepath: Path, cmap: str = "gray",
             print(f"  SCP:            ({scp_llh.lat:.6f}, {scp_llh.lon:.6f}, "
                   f"{scp_llh.hae:.1f} m)")
 
-        # Print SCPCOA (Scene Center Point Center of Aperture)
         scpcoa = meta.scpcoa
         if scpcoa is not None:
             print(f"  Side of track:  {scpcoa.side_of_track or '?'}")
-            print(f"  SCP COA time:   {scpcoa.scp_time:.6f} s" if scpcoa.scp_time is not None else "  SCP COA time:   ?")
+            if scpcoa.scp_time is not None:
+                print(f"  SCP COA time:   {scpcoa.scp_time:.6f} s")
+            else:
+                print("  SCP COA time:   ?")
             if scpcoa.slant_range is not None:
                 print(f"  Slant range:    {scpcoa.slant_range:,.1f} m")
             if scpcoa.ground_range is not None:
@@ -176,63 +144,18 @@ def view_sicd(filepath: Path, cmap: str = "gray",
                 a = scpcoa.arp_acc
                 print(f"  ARP accel:      ({a.x:.4f}, {a.y:.4f}, {a.z:.4f}) m/s^2")
 
-        # Get SCP pixel location for annotation
-        scp_pixel = None
-        if meta.image_data is not None:
-            scp_pixel = meta.image_data.scp_pixel
         print()
 
-        # Read full complex image
-        print(f"Reading full image ({rows} x {cols})...")
-        complex_data = reader.read_full()
-        print(f"  Shape: {complex_data.shape}, dtype: {complex_data.dtype}")
+        # Build title from filename and collector
+        title_parts = [filepath.name]
+        if ci is not None and ci.collector_name:
+            title_parts.append(ci.collector_name)
+        title = "  |  ".join(title_parts)
 
-    # Compute linear magnitude
-    magnitude = np.abs(complex_data)
-
-    # Contrast stretch
-    vmin = np.percentile(magnitude, plow)
-    vmax = np.percentile(magnitude, phigh)
-    print(f"  Magnitude range: [{magnitude.min():.4f}, {magnitude.max():.4f}]")
-    print(f"  Display range:   [{vmin:.4f}, {vmax:.4f}] "
-          f"(p{plow:.0f}-p{phigh:.0f})")
-    print()
-
-    # Build title
-    title_parts = [filepath.name]
-    if ci is not None and ci.collector_name:
-        title_parts.append(ci.collector_name)
-    title = "  |  ".join(title_parts)
-
-    # Display
-    fig, ax = plt.subplots(1, 1, figsize=(12, 10))
-    im = ax.imshow(
-        magnitude, cmap=cmap, vmin=vmin, vmax=vmax,
-        aspect="auto", interpolation="nearest",
-    )
-    ax.set_title(f"SICD Magnitude (linear)\n{title}", fontsize=10)
-    ax.set_xlabel("Column (range)")
-    ax.set_ylabel("Row (azimuth)")
-    fig.colorbar(im, ax=ax, label="Magnitude", shrink=0.8)
-
-    # Annotate SCP if available
-    if scp_llh is not None:
-        scp_row = int(scp_pixel.row) if scp_pixel is not None else rows // 2
-        scp_col = int(scp_pixel.col) if scp_pixel is not None else cols // 2
-        ax.plot(scp_col, scp_row, 'r*', markersize=12, markeredgecolor='black',
-                markeredgewidth=0.5, zorder=5)
-        ax.annotate(
-            f"SCP\n({scp_llh.lat:.4f}, {scp_llh.lon:.4f})",
-            xy=(scp_col, scp_row), xytext=(12, 0),
-            textcoords="offset points", fontsize=8,
-            color="red", fontweight="bold",
-            bbox=dict(boxstyle="round,pad=0.2", fc="black", alpha=0.6),
-        )
-
-    plt.tight_layout()
-    plt.show()
+        geo = create_geolocation(reader)
+        show(reader, geolocation=geo, title=title, block=True)
 
 
 if __name__ == "__main__":
     args = parse_args()
-    view_sicd(args.filepath, cmap=args.cmap, plow=args.plow, phigh=args.phigh)
+    view_sicd(args.filepath)

--- a/grdl/example/image_processing/sar/cphd_to_sicd_example.py
+++ b/grdl/example/image_processing/sar/cphd_to_sicd_example.py
@@ -551,11 +551,14 @@ def convert(
         Optional YAML tuning config.
     launch_viewer : bool
         If True (default), open the written SICD in grdk-viewer.
+    dry_run : bool
+        If True, run the conversion pipeline without writing the SICD file
+        or launching the viewer.
 
     Returns
     -------
-    Path
-        Path of the written SICD file.
+    Optional[Path]
+        Path of the written SICD file, or ``None`` when ``dry_run=True``.
     """
     t0 = time.perf_counter()
 

--- a/grdl/example/image_processing/sar/cphd_to_sicd_example.py
+++ b/grdl/example/image_processing/sar/cphd_to_sicd_example.py
@@ -636,7 +636,7 @@ def convert(
 
     # ── Launch viewer ────────────────────────────────────────────
     if launch_viewer:
-        print(f"\nLaunching grdk-viewer...")
+        print("\nLaunching grdk-viewer...")
         subprocess.Popen(
             ['grdk-viewer', str(output_path)],
             stdout=subprocess.DEVNULL,

--- a/grdl/example/image_processing/sar/cphd_to_sicd_example.py
+++ b/grdl/example/image_processing/sar/cphd_to_sicd_example.py
@@ -1,0 +1,660 @@
+# -*- coding: utf-8 -*-
+"""
+CPHD-to-SICD Example - Convert CPHD phase history to a SICD image file.
+
+Reads a CPHD file, selects an image formation processor (IFP) based on
+the collection mode recorded in the metadata (SPOTLIGHT → PFA, STRIPMAP /
+DYNAMIC STRIPMAP → RDA), forms the complex SAR image, writes it as a SICD
+NITF, and optionally opens the result in grdk-viewer.
+
+All parameters needed for image formation (waveform, PVP, frequency band,
+geometry) are derived entirely from the CPHD metadata — no sensor-specific
+knowledge is required beyond what the CPHD file itself contains.
+
+Output path defaults to the input path with:
+  - the file extension replaced by ``.nitf``
+  - any occurrence of ``cphd`` in the filename stem replaced by ``sicd``
+
+An optional YAML configuration file can override the auto-selected algorithm
+and set algorithm-specific tuning parameters.  See the ``--config`` argument
+and the example YAML block below.
+
+Example YAML config (cphd_to_sicd.yaml)
+-----------------------------------------
+::
+
+    # Algorithm override — omit to use metadata-driven auto-selection.
+    # Choices: PFA | RDA | FFBP | StripmapPFA
+    algorithm: PFA
+
+    # slant: true uses slant plane geometry (default); false uses ground plane.
+    slant: true
+
+    pfa:
+      grid_mode: inscribed        # inscribed | circumscribed
+      range_oversample: 1.0       # 1.0 = Nyquist
+      azimuth_oversample: 1.0
+      weighting: uniform          # uniform | taylor | hamming | hanning
+      interpolator:
+        type: polyphase           # polyphase | kaiser_sinc (default)
+        kernel_length: 8          # filter taps
+        num_phases: 128           # polyphase branches
+        prototype: kaiser         # kaiser | remez
+
+    rda:
+      range_weighting: taylor     # uniform | taylor | hamming | hanning
+      azimuth_weighting: uniform
+      block_size: null            # null = full aperture, 'auto', or integer
+      overlap: 0.5                # subaperture overlap fraction
+
+    ffbp:
+      leaf_size: 8
+      n_angular: 128
+      apply_amp_sf: true
+
+    stripmap_pfa:
+      subaperture_pulses: 4096
+      overlap: 0.3
+
+Usage
+-----
+::
+
+    python cphd_to_sicd_example.py <cphd_file>
+    python cphd_to_sicd_example.py <cphd_file> --output formed.sicd
+    python cphd_to_sicd_example.py <cphd_file> --config cphd_to_sicd.yaml
+    python cphd_to_sicd_example.py <cphd_file> --no-viewer
+    python cphd_to_sicd_example.py --help
+
+Dependencies
+------------
+sarkit or sarpy
+pyyaml (optional, required only when --config is used)
+
+Author
+------
+Jason Fritz
+43161141+stryder-vtx@users.noreply.github.com
+
+License
+-------
+MIT License
+Copyright (c) 2026 geoint.org
+See LICENSE file for full text.
+
+Created
+-------
+2026-05-14
+
+Modified
+--------
+2026-05-14
+"""
+
+# Standard library
+import argparse
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+# Third-party
+import numpy as np
+
+# GRDL — resolve package root when run directly
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from grdl.IO.sar import CPHDReader, SICDWriter
+from grdl.IO.sar.cphd_to_sicd import build_sicd_metadata
+from grdl.image_processing.sar import CollectionGeometry
+from grdl.image_processing.sar.image_formation.base import (
+    ImageFormationAlgorithm,
+)
+
+
+# ── Constants ────────────────────────────────────────────────────────
+
+# Maps internal algorithm names to the SICD ImageFormation/ImageFormAlgo tag.
+# RDA outputs in range-Doppler (RGZERO) domain → RGAZCOMP.
+# FFBP is not a named SICD algorithm → OTHER.
+_ALGO_SICD_TAG: Dict[str, str] = {
+    'PFA':          'PFA',
+    'RDA':          'RGAZCOMP',
+    'FFBP':         'OTHER',
+    'StripmapPFA':  'PFA',
+}
+
+# Maps CPHD radar_mode to default algorithm name.
+_MODE_DEFAULT_ALGO: Dict[str, str] = {
+    'SPOTLIGHT':        'PFA',
+    'STRIPMAP':         'RDA',
+    'DYNAMIC STRIPMAP': 'RDA',
+}
+
+# Config sub-key for each algorithm's tuning section.
+_ALGO_CFG_KEY: Dict[str, str] = {
+    'PFA':          'pfa',
+    'RDA':          'rda',
+    'FFBP':         'ffbp',
+    'StripmapPFA':  'stripmap_pfa',
+}
+
+
+# ── CLI ──────────────────────────────────────────────────────────────
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Returns
+    -------
+    argparse.Namespace
+        Parsed arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert a CPHD file to SICD using an IFP selected from "
+            "the collection metadata.  The output file is always written."
+        ),
+    )
+    parser.add_argument(
+        'input',
+        type=Path,
+        help='Path to the input CPHD file.',
+    )
+    parser.add_argument(
+        '--output', '-o',
+        type=Path,
+        default=None,
+        help=(
+            'Output SICD path.  Defaults to the input path with the '
+            'extension replaced by .nitf and any "cphd" in the stem '
+            'replaced by "sicd".'
+        ),
+    )
+    parser.add_argument(
+        '--config', '-c',
+        type=Path,
+        default=None,
+        help=(
+            'Optional YAML config file for algorithm selection and '
+            'tuning parameters.  See module docstring for the format.'
+        ),
+    )
+    parser.add_argument(
+        '--no-viewer',
+        action='store_true',
+        default=False,
+        help='Skip launching grdk-viewer after writing the SICD file.',
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        default=False,
+        help=(
+            'Print geometry and grid diagnostics then exit without '
+            'running image formation or writing any output.'
+        ),
+    )
+    return parser.parse_args()
+
+
+# ── Output path ──────────────────────────────────────────────────────
+
+
+def derive_output_path(input_path: Path) -> Path:
+    """Derive the default SICD output path from the CPHD input path.
+
+    Replaces the file extension with ``.sicd`` and substitutes any
+    occurrence of ``cphd`` (case-insensitive) in the stem with ``sicd``.
+
+    Parameters
+    ----------
+    input_path : Path
+        Path to the input CPHD file.
+
+    Returns
+    -------
+    Path
+        Derived output path in the same directory as the input.
+    """
+    stem = re.sub(r'(?i)cphd', 'sicd', input_path.stem)
+    return input_path.with_name(stem + '.nitf')
+
+
+# ── Config loading ───────────────────────────────────────────────────
+
+
+def load_config(config_path: Optional[Path]) -> Dict[str, Any]:
+    """Load the optional YAML tuning config.
+
+    Parameters
+    ----------
+    config_path : Path or None
+        Path to the YAML file, or None to return an empty dict.
+
+    Returns
+    -------
+    dict
+        Parsed config dict (empty when no file is provided).
+    """
+    if config_path is None:
+        return {}
+    try:
+        import yaml
+    except ImportError as exc:
+        raise ImportError(
+            "pyyaml is required to use --config: pip install pyyaml"
+        ) from exc
+    with open(config_path) as fh:
+        return yaml.safe_load(fh) or {}
+
+
+# ── Algorithm selection ───────────────────────────────────────────────
+
+
+def select_algorithm(meta: Any, config: Dict[str, Any]) -> str:
+    """Choose the IFP algorithm name.
+
+    Precedence: explicit ``algorithm`` key in config > CPHD radar_mode.
+
+    Parameters
+    ----------
+    meta : CPHDMetadata
+        CPHD metadata from the reader.
+    config : dict
+        Loaded YAML config (may be empty).
+
+    Returns
+    -------
+    str
+        One of ``'PFA'``, ``'RDA'``, ``'FFBP'``, ``'StripmapPFA'``.
+    """
+    if 'algorithm' in config:
+        algo = config['algorithm']
+        if algo not in _ALGO_SICD_TAG:
+            raise ValueError(
+                f"Unknown algorithm {algo!r} in config.  "
+                f"Valid choices: {list(_ALGO_SICD_TAG)}"
+            )
+        print(f"  Algorithm: {algo} (from config)")
+        return algo
+
+    radar_mode = ''
+    if meta.collection_info is not None:
+        radar_mode = (meta.collection_info.radar_mode or '').upper()
+
+    algo = _MODE_DEFAULT_ALGO.get(radar_mode, 'PFA')
+    if radar_mode not in _MODE_DEFAULT_ALGO:
+        print(
+            f"  Warning: unrecognised radar_mode {radar_mode!r}, "
+            "defaulting to PFA."
+        )
+    else:
+        print(f"  Algorithm: {algo} (auto from radar_mode={radar_mode!r})")
+    return algo
+
+
+# ── IFP builders ─────────────────────────────────────────────────────
+#
+# Each builder constructs and returns a fully configured IFP object that
+# implements ImageFormationAlgorithm (form_image + get_output_grid).
+# The convert() function calls form_image() and get_output_grid() itself
+# so they are only invoked once.
+
+
+def _build_pfa_interpolator(interp_cfg: Dict[str, Any]) -> Any:
+    """Construct a PFA interpolator from a config dict.
+
+    Parameters
+    ----------
+    interp_cfg : dict
+        ``pfa.interpolator`` sub-dict.  Recognised keys:
+
+        ``type`` : str
+            ``'polyphase'`` or ``'kaiser_sinc'``.
+            Default ``'kaiser_sinc'`` (PFA built-in default).
+        ``kernel_length`` : int
+            Filter kernel length in taps.
+        ``num_phases`` : int
+            Number of polyphase branches (``polyphase`` only).
+        ``beta`` : float
+            Kaiser window shape parameter.
+        ``prototype`` : str
+            ``'kaiser'`` or ``'remez'`` (``polyphase`` only).
+
+    Returns
+    -------
+    callable or None
+        Interpolator instance, or ``None`` to use the PFA default.
+    """
+    if not interp_cfg:
+        return None
+
+    interp_type = interp_cfg.get('type', 'kaiser_sinc')
+
+    if interp_type == 'polyphase':
+        from grdl.interpolation import PolyphaseInterpolator
+        return PolyphaseInterpolator(
+            kernel_length=int(interp_cfg.get('kernel_length', 8)),
+            num_phases=int(interp_cfg.get('num_phases', 128)),
+            beta=float(interp_cfg.get('beta', 5.0)),
+            prototype=str(interp_cfg.get('prototype', 'kaiser')),
+        )
+    if interp_type == 'kaiser_sinc':
+        from grdl.interpolation import KaiserSincInterpolator
+        return KaiserSincInterpolator(
+            kernel_length=int(interp_cfg.get('kernel_length', 8)),
+            beta=float(interp_cfg.get('beta', 5.0)),
+        )
+    raise ValueError(
+        f"Unknown interpolator type {interp_type!r}.  "
+        "Valid choices: 'polyphase', 'kaiser_sinc'."
+    )
+
+
+def build_pfa(
+    meta: Any,
+    geo: CollectionGeometry,
+    cfg: Dict[str, Any],
+) -> ImageFormationAlgorithm:
+    """Build a PolarFormatAlgorithm for spotlight collections.
+
+    Parameters
+    ----------
+    meta : CPHDMetadata
+        CPHD metadata.
+    geo : CollectionGeometry
+        Pre-computed collection geometry.
+    cfg : dict
+        ``pfa`` sub-dict from the YAML config (may be empty).
+
+    Returns
+    -------
+    PolarFormatAlgorithm
+        Configured IFP ready for ``form_image(signal, geo)``.
+    """
+    from grdl.image_processing.sar import PolarGrid, PolarFormatAlgorithm
+
+    grid_mode        = cfg.get('grid_mode', 'inscribed')
+    range_oversample = float(cfg.get('range_oversample', 1.0))
+    az_oversample    = float(cfg.get('azimuth_oversample', 1.0))
+    weighting        = cfg.get('weighting', 'uniform')
+    interpolator     = _build_pfa_interpolator(cfg.get('interpolator') or {})
+
+    grid = PolarGrid(
+        geo,
+        grid_mode=grid_mode,
+        range_oversample=range_oversample,
+        azimuth_oversample=az_oversample,
+    )
+    d = grid._diag
+    print(f"  PolarGrid ({grid_mode}): {grid.rec_n_pulses} x {grid.rec_n_samples}  "
+          f"rng_res={grid.range_resolution:.3f}m  az_res={grid.azimuth_resolution:.3f}m")
+    print(f"  [diag] input: {d['npulses']} pulses x {d['nsamples']} samples")
+    print(f"  [diag] proc_bw={d['proc_bw']:.3e} Hz  kv_span={d['kv_span']:.6e} 1/m  "
+          f"ku_span={d['ku_span']:.6e} 1/m")
+    print(f"  [diag] scene_range={d['scene_range']:.1f}m  scene_az={d['scene_az']:.1f}m  "
+          f"graze={d['mean_graze_deg']:.2f}°")
+
+    gp        = meta.global_params
+    phase_sgn = gp.phase_sgn if gp is not None else -1
+
+    kwargs: Dict[str, Any] = dict(grid=grid, weighting=weighting, phase_sgn=phase_sgn)
+    if interpolator is not None:
+        kwargs['interpolator'] = interpolator
+
+    return PolarFormatAlgorithm(**kwargs)
+
+
+def build_rda(
+    meta: Any,
+    geo: CollectionGeometry,
+    cfg: Dict[str, Any],
+) -> ImageFormationAlgorithm:
+    """Build a RangeDopplerAlgorithm for stripmap collections.
+
+    Parameters
+    ----------
+    meta : CPHDMetadata
+        CPHD metadata (RDA reads PVP arrays directly from it).
+    geo : CollectionGeometry
+        Pre-computed collection geometry (passed through to form_image).
+    cfg : dict
+        ``rda`` sub-dict from the YAML config (may be empty).
+
+    Returns
+    -------
+    RangeDopplerAlgorithm
+        Configured IFP ready for ``form_image(signal, geo)``.
+    """
+    from grdl.image_processing.sar.image_formation.rda import (
+        RangeDopplerAlgorithm,
+    )
+
+    range_weighting   = cfg.get('range_weighting', 'uniform')
+    azimuth_weighting = cfg.get('azimuth_weighting', 'uniform')
+    block_size        = cfg.get('block_size', None)
+    overlap           = float(cfg.get('overlap', 0.5))
+
+    print(f"  RDA: rng_wt={range_weighting}  az_wt={azimuth_weighting}  "
+          f"block_size={block_size}  overlap={overlap}")
+    return RangeDopplerAlgorithm(
+        meta,
+        range_weighting=range_weighting,
+        azimuth_weighting=azimuth_weighting,
+        block_size=block_size,
+        overlap=overlap,
+    )
+
+
+def build_ffbp(
+    meta: Any,
+    geo: CollectionGeometry,
+    cfg: Dict[str, Any],
+) -> ImageFormationAlgorithm:
+    """Build a FastBackProjection IFP.
+
+    Parameters
+    ----------
+    meta : CPHDMetadata
+        CPHD metadata.
+    geo : CollectionGeometry
+        Pre-computed collection geometry.
+    cfg : dict
+        ``ffbp`` sub-dict from the YAML config (may be empty).
+
+    Returns
+    -------
+    FastBackProjection
+        Configured IFP ready for ``form_image(signal, geo)``.
+    """
+    from grdl.image_processing.sar.image_formation.ffbp import (
+        FastBackProjection,
+    )
+
+    leaf_size    = int(cfg.get('leaf_size', 8))
+    n_angular    = int(cfg.get('n_angular', 128))
+    apply_amp_sf = bool(cfg.get('apply_amp_sf', True))
+
+    print(f"  FFBP: leaf_size={leaf_size}  n_angular={n_angular}  "
+          f"apply_amp_sf={apply_amp_sf}")
+    return FastBackProjection(
+        leaf_size=leaf_size,
+        n_angular=n_angular,
+        apply_amp_sf=apply_amp_sf,
+    )
+
+
+def build_stripmap_pfa(
+    meta: Any,
+    geo: CollectionGeometry,
+    cfg: Dict[str, Any],
+) -> ImageFormationAlgorithm:
+    """Build a StripmapPFA IFP (subaperture PFA mosaic).
+
+    Parameters
+    ----------
+    meta : CPHDMetadata
+        CPHD metadata.
+    geo : CollectionGeometry
+        Pre-computed collection geometry.
+    cfg : dict
+        ``stripmap_pfa`` sub-dict from the YAML config (may be empty).
+
+    Returns
+    -------
+    StripmapPFA
+        Configured IFP ready for ``form_image(signal, geo)``.
+    """
+    from grdl.image_processing.sar import StripmapPFA
+
+    overlap = float(cfg.get('overlap', 0.3))
+    kwargs: Dict[str, Any] = {'overlap': overlap}
+    if 'subaperture_pulses' in cfg:
+        kwargs['subaperture_pulses'] = int(cfg['subaperture_pulses'])
+
+    print(f"  StripmapPFA: overlap={overlap}  "
+          f"subaperture_pulses={cfg.get('subaperture_pulses', 'auto')}")
+    return StripmapPFA(meta, **kwargs)
+
+
+_BUILDERS = {
+    'PFA':          build_pfa,
+    'RDA':          build_rda,
+    'FFBP':         build_ffbp,
+    'StripmapPFA':  build_stripmap_pfa,
+}
+
+
+# ── Main pipeline ────────────────────────────────────────────────────
+
+
+def convert(
+    input_path: Path,
+    output_path: Optional[Path] = None,
+    config_path: Optional[Path] = None,
+    launch_viewer: bool = True,
+    dry_run: bool = False,
+) -> Optional[Path]:
+    """Full CPHD-to-SICD conversion pipeline.
+
+    Parameters
+    ----------
+    input_path : Path
+        Path to the input CPHD file.
+    output_path : Path, optional
+        Destination SICD path.  Derived from ``input_path`` when omitted.
+    config_path : Path, optional
+        Optional YAML tuning config.
+    launch_viewer : bool
+        If True (default), open the written SICD in grdk-viewer.
+
+    Returns
+    -------
+    Path
+        Path of the written SICD file.
+    """
+    t0 = time.perf_counter()
+
+    # ── Resolve output path ──────────────────────────────────────
+    if output_path is None:
+        output_path = derive_output_path(input_path)
+    print(f"Input : {input_path}")
+    print(f"Output: {output_path}")
+
+    # ── Load config ──────────────────────────────────────────────
+    config = load_config(config_path)
+    if config_path is not None:
+        print(f"Config: {config_path}")
+
+    # ── Read CPHD ────────────────────────────────────────────────
+    print("\n[1/5] Reading CPHD...")
+    with CPHDReader(input_path) as reader:
+        meta         = reader.metadata
+        nrows, ncols = reader.get_shape()
+        print(f"  Phase history: {nrows} pulses x {ncols} samples")
+        if meta.collection_info is not None:
+            ci = meta.collection_info
+            print(f"  Collector : {ci.collector_name or 'unknown'}")
+            print(f"  Radar mode: {ci.radar_mode or 'unknown'}")
+        signal = reader.read_full()
+    t_read = time.perf_counter()
+    print(f"  Read time: {t_read - t0:.2f}s")
+
+    # ── Select algorithm ─────────────────────────────────────────
+    print("\n[2/5] Selecting algorithm...")
+    algo     = select_algorithm(meta, config)
+    algo_cfg = config.get(_ALGO_CFG_KEY[algo], {})
+    sicd_tag = _ALGO_SICD_TAG[algo]
+
+    # ── Collection geometry ──────────────────────────────────────
+    print("\n[3/5] Computing collection geometry...")
+    slant = bool(config.get('slant', True))
+    geo   = CollectionGeometry(meta, slant=slant)
+    print(f"  Image plane  : {geo.image_plane}")
+    print(f"  Side of track: {geo.side_of_track}")
+    print(f"  Graze (COA)  : {np.degrees(geo.graz_ang_coa):.2f}°")
+    print(f"  Azimuth (COA): {np.degrees(geo.azim_ang_coa):.2f}°")
+    t_geo = time.perf_counter()
+    print(f"  Geometry time: {t_geo - t_read:.2f}s")
+
+    # ── Build IFP (and optionally stop for dry-run) ──────────────
+    print(f"\n[4/5] Forming image with {algo}...")
+    ifp   = _BUILDERS[algo](meta, geo, algo_cfg)
+
+    if dry_run:
+        print("\n  --dry-run: stopping after grid diagnostics.")
+        return None
+
+    image = ifp.form_image(signal, geo)
+    if image.dtype != np.complex64:
+        image = image.astype(np.complex64)
+    grid_params = ifp.get_output_grid()
+    print(f"  Image shape: {image.shape}  dtype: {image.dtype}")
+    t_ifp = time.perf_counter()
+    print(f"  IFP time: {t_ifp - t_geo:.2f}s")
+
+    # ── Build SICD metadata and write ────────────────────────────
+    print(f"\n[5/5] Writing SICD ({sicd_tag})...")
+    sicd_meta = build_sicd_metadata(
+        meta,
+        geo,
+        image.shape,
+        image_form_algo=sicd_tag,
+        grid_params=grid_params,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    writer = SICDWriter(output_path, metadata=sicd_meta)
+    writer.write(image)
+    t_write = time.perf_counter()
+    print(f"  Write time: {t_write - t_ifp:.2f}s")
+
+    print(f"\nTotal: {t_write - t0:.2f}s  →  {output_path}")
+
+    # ── Launch viewer ────────────────────────────────────────────
+    if launch_viewer:
+        print(f"\nLaunching grdk-viewer...")
+        subprocess.Popen(
+            ['grdk-viewer', str(output_path)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    return output_path
+
+
+# ── Entry point ──────────────────────────────────────────────────────
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    convert(
+        input_path=args.input,
+        output_path=args.output,
+        config_path=args.config,
+        launch_viewer=not args.no_viewer,
+        dry_run=args.dry_run,
+    )

--- a/grdl/example/image_processing/sar/cphd_to_sicd_example.py
+++ b/grdl/example/image_processing/sar/cphd_to_sicd_example.py
@@ -207,7 +207,7 @@ def parse_args() -> argparse.Namespace:
 def derive_output_path(input_path: Path) -> Path:
     """Derive the default SICD output path from the CPHD input path.
 
-    Replaces the file extension with ``.sicd`` and substitutes any
+    Replaces the file extension with ``.nitf`` and substitutes any
     occurrence of ``cphd`` (case-insensitive) in the stem with ``sicd``.
 
     Parameters

--- a/grdl/example/image_processing/sar/cphd_to_sicd_example.py
+++ b/grdl/example/image_processing/sar/cphd_to_sicd_example.py
@@ -390,14 +390,17 @@ def build_pfa(
         range_oversample=range_oversample,
         azimuth_oversample=az_oversample,
     )
-    d = grid._diag
+    diagnostics = getattr(grid, 'diagnostics', None)
     print(f"  PolarGrid ({grid_mode}): {grid.rec_n_pulses} x {grid.rec_n_samples}  "
           f"rng_res={grid.range_resolution:.3f}m  az_res={grid.azimuth_resolution:.3f}m")
-    print(f"  [diag] input: {d['npulses']} pulses x {d['nsamples']} samples")
-    print(f"  [diag] proc_bw={d['proc_bw']:.3e} Hz  kv_span={d['kv_span']:.6e} 1/m  "
-          f"ku_span={d['ku_span']:.6e} 1/m")
-    print(f"  [diag] scene_range={d['scene_range']:.1f}m  scene_az={d['scene_az']:.1f}m  "
-          f"graze={d['mean_graze_deg']:.2f}°")
+    if isinstance(diagnostics, dict):
+        print(f"  [diag] input: {diagnostics['npulses']} pulses x {diagnostics['nsamples']} samples")
+        print(f"  [diag] proc_bw={diagnostics['proc_bw']:.3e} Hz  "
+              f"kv_span={diagnostics['kv_span']:.6e} 1/m  "
+              f"ku_span={diagnostics['ku_span']:.6e} 1/m")
+        print(f"  [diag] scene_range={diagnostics['scene_range']:.1f}m  "
+              f"scene_az={diagnostics['scene_az']:.1f}m  "
+              f"graze={diagnostics['mean_graze_deg']:.2f}°")
 
     gp        = meta.global_params
     phase_sgn = gp.phase_sgn if gp is not None else -1

--- a/grdl/example/image_processing/sar/cphd_to_sicd_example.py
+++ b/grdl/example/image_processing/sar/cphd_to_sicd_example.py
@@ -61,7 +61,7 @@ Usage
 ::
 
     python cphd_to_sicd_example.py <cphd_file>
-    python cphd_to_sicd_example.py <cphd_file> --output formed.sicd
+    python cphd_to_sicd_example.py <cphd_file> --output formed.nitf
     python cphd_to_sicd_example.py <cphd_file> --config cphd_to_sicd.yaml
     python cphd_to_sicd_example.py <cphd_file> --no-viewer
     python cphd_to_sicd_example.py --help

--- a/grdl/example/image_processing/sar/ifp_example.py
+++ b/grdl/example/image_processing/sar/ifp_example.py
@@ -386,6 +386,7 @@ def run_ifp(
     title = filepath.name
     if meta.collection_info and meta.collection_info.collector_name:
         title += f"  |  {meta.collection_info.collector_name}"
+    print(f"\nDisplaying image with title: {title}")
     display_image(image, signal, title=title)
 
     return image

--- a/grdl/image_processing/sar/image_formation/geometry.py
+++ b/grdl/image_processing/sar/image_formation/geometry.py
@@ -32,7 +32,7 @@ Created
 
 Modified
 --------
-2026-05-07
+2026-05-15
 """
 
 # Standard library
@@ -155,6 +155,10 @@ class CollectionGeometry:
         self.fx2 = pvp.fx2
         self.fxss = pvp.scss if pvp.scss is not None else np.zeros(self.npulses)
         self.fx0 = pvp.sc0 if pvp.sc0 is not None else pvp.fx1
+
+        # Receive window (TOA) parameters — used by PolarGrid for scene extent
+        self.toa1 = pvp.toa1
+        self.toa2 = pvp.toa2
 
         # Build geometry
         self._build_reference_vectors(pvp)

--- a/grdl/image_processing/sar/image_formation/pfa.py
+++ b/grdl/image_processing/sar/image_formation/pfa.py
@@ -37,7 +37,9 @@ Created
 
 Modified
 --------
-2026-05-08
+2026-05-14  Cast CI2/CI4 structured int signal to complex64 in
+            interpolate_range so numba kernels receive a standard
+            floating-point complex dtype (fixes Capella CPHD).
 """
 
 # Standard library
@@ -230,6 +232,16 @@ class PolarFormatAlgorithm(ImageFormationAlgorithm):
             Range-interpolated data, shape
             ``(npulses, rec_n_samples)``.
         """
+        # CPHD CI2/CI4 signals arrive as structured numpy arrays with
+        # 'real' and 'imag' integer fields (e.g. Capella spotlight).
+        # Cast to complex64 so all downstream arithmetic and numba
+        # kernels receive a standard floating-point complex dtype.
+        if signal.dtype.names is not None:
+            signal = (signal['real'].astype(np.float32)
+                      + 1j * signal['imag'].astype(np.float32))
+        elif not np.issubdtype(signal.dtype, np.complexfloating):
+            signal = signal.astype(np.complex64)
+
         pg = self.grid
         npulses = signal.shape[0]
 

--- a/grdl/image_processing/sar/image_formation/polar_grid.py
+++ b/grdl/image_processing/sar/image_formation/polar_grid.py
@@ -28,11 +28,14 @@ Created
 
 Modified
 --------
-2026-05-05
+2026-05-15  Fix rec_n_samples / rec_n_pulses: size the output grid to the
+            scene illumination footprint (TOA receive window × graze angle)
+            instead of the CPHD unambiguous range, which inflated output by
+            4–10× for CPHDs with long unambiguous-range windows.
 """
 
 # Standard library
-from typing import Dict, Optional, Tuple
+from typing import Dict, Tuple
 
 # Third-party
 import numpy as np
@@ -200,9 +203,14 @@ class PolarGrid:
         """Compute resolution, sampling, and resampled grid dimensions.
 
         Resolution is determined entirely by the k-space bandwidth
-        (kv/ku bounds).  The oversampling factors control only the
-        number of samples in the rectangular grid — they change the
-        sampling density without affecting bandwidth or resolution.
+        (kv/ku bounds).  The grid *dimensions* (rec_n_samples,
+        rec_n_pulses) are determined by the scene illumination extent
+        derived from the CPHD receive-window (TOA) duration and the
+        mean grazing angle, not by the CPHD sampling density.
+
+        The oversampling factors scale the number of output pixels
+        above the Nyquist baseline without affecting bandwidth or
+        resolution.
         """
         xp = self._xp
         geo = self.geometry
@@ -221,45 +229,53 @@ class PolarGrid:
         ku_span = float(abs(self.ku_bounds[1] - self.ku_bounds[0]))
         self.azimuth_resolution = 0.886 / ku_span
 
-        # Range sampling: Nyquist from receive window length.
-        #
-        # For an alias-free output that covers the full unambiguous
-        # receive-window swath D = c * T / 2 (where T is the receive
-        # window length), we need at least N samples such that the
-        # output spatial extent N / kv_span >= D, i.e.
-        #   N >= D * kv_span = (c * T / 2) * (2 * proc_bw / c)
-        #      = T * proc_bw.
-        # Equivalently, the Nyquist frequency-sample spacing is
-        # 1 / T (one freq bin per receive-window time).
-        #
-        # The 0.886 factor is the IPR width constant for an unweighted
-        # sinc and belongs in resolution formulas, not sampling. The
-        # range_oversample factor scales density above this Nyquist
-        # baseline. Falls back to the per-pulse frequency step from
-        # the CPHD geometry when the receive-window length is
-        # unavailable.
-        rcv_params = self._get_rcv_window()
-        if rcv_params is not None:
-            nyquist_freq_sampling = 1.0 / rcv_params
+        # K-space bandwidths (1/m)
+        kv_span = float(abs(self.kv_bounds[1] - self.kv_bounds[0]))
+
+        # Scene extent from TOA receive window.
+        # scene_range = c × mean(toa2 − toa1) / 2
+        toa1 = getattr(geo, 'toa1', None)
+        toa2 = getattr(geo, 'toa2', None)
+        if toa1 is not None and toa2 is not None:
+            toa_window = float(np.mean(np.abs(toa2 - toa1)))
+            scene_range = c * toa_window / 2.0
         else:
-            nyquist_freq_sampling = float(geo.fxss[0])
+            # Fallback: use unambiguous range from fxss (less accurate)
+            fxss0 = float(geo.fxss[0]) if geo.fxss is not None else 0.0
+            if fxss0 > 0.0:
+                scene_range = c / (2.0 * fxss0)
+            else:
+                raw_bw = float(np.mean(np.abs(geo.fx2 - geo.fx1)))
+                scene_range = (
+                    c * max(geo.nsamples - 1, 1) / (2.0 * raw_bw)
+                    if raw_bw > 0.0 else 1.0
+                )
 
         self.rec_n_samples = max(
             1,
-            int(np.ceil(self.proc_bw / nyquist_freq_sampling
-                        * self.range_oversample)),
+            int(np.ceil(kv_span * scene_range * self.range_oversample)),
         )
 
-        # Azimuth sampling: minimum ku step between adjacent pulses,
-        # then scale by oversampling factor
-        az_sf_sampling = float(xp.min(xp.abs(xp.diff(
-            self.kv_bounds[0] * xp.tan(geo.phi),
-        )))) * 0.889
+        # Azimuth scene extent: scene_range / cos(mean grazing angle)
+        mean_graze = float(np.mean(geo.graz_ang))
+        scene_az = scene_range / max(np.cos(mean_graze), 0.1)
 
         self.rec_n_pulses = max(
             1,
-            int(ku_span / az_sf_sampling * self.azimuth_oversample),
+            int(np.ceil(ku_span * scene_az * self.azimuth_oversample)),
         )
+
+        # Diagnostic: log grid sizing inputs so callers can verify
+        self._diag = {
+            'npulses': geo.npulses,
+            'nsamples': geo.nsamples,
+            'proc_bw': self.proc_bw,
+            'kv_span': kv_span,
+            'ku_span': ku_span,
+            'scene_range': scene_range,
+            'scene_az': scene_az,
+            'mean_graze_deg': float(np.degrees(mean_graze)),
+        }
 
         # SICD Grid parameters
         self.rg_imp_resp_bw = float(self.kv_bounds[1] - self.kv_bounds[0])
@@ -273,17 +289,6 @@ class PolarGrid:
         self.az_imp_resp_wid = 0.886 / self.az_imp_resp_bw
         self.az_ss = 1.0 / self.az_imp_resp_bw
         self.az_kctr = float(xp.mean(self.ku_bounds))
-
-    def _get_rcv_window(self) -> Optional[float]:
-        """Get receive window length from metadata."""
-        rcv = self._get_metadata_attr('rcv_parameters')
-        if rcv is not None:
-            return getattr(rcv, 'window_length', None)
-        return None
-
-    def _get_metadata_attr(self, name: str):
-        """Safely get an attribute from the metadata."""
-        return getattr(self.geometry._metadata, name, None)
 
     # ------------------------------------------------------------------
     # Polar grid sample accessors (used by PFA)

--- a/grdl/image_processing/sar/image_formation/polar_grid.py
+++ b/grdl/image_processing/sar/image_formation/polar_grid.py
@@ -28,6 +28,9 @@ Created
 
 Modified
 --------
+2026-05-19  Use a positive-value check for fxss fallback selection so the
+            unambiguous-range estimate is only used when fxss is actually
+            populated, not merely allocated.
 2026-05-15  Fix rec_n_samples / rec_n_pulses: size the output grid to the
             scene illumination footprint (TOA receive window × graze angle)
             instead of the CPHD unambiguous range, which inflated output by
@@ -241,8 +244,10 @@ class PolarGrid:
             scene_range = c * toa_window / 2.0
         else:
             # Fallback: use unambiguous range from fxss (less accurate)
-            fxss0 = float(geo.fxss[0]) if geo.fxss is not None else 0.0
-            if fxss0 > 0.0:
+            fxss = np.asarray(geo.fxss)
+            positive_fxss = fxss[fxss > 0.0]
+            if positive_fxss.size > 0:
+                fxss0 = float(np.mean(positive_fxss))
                 scene_range = c / (2.0 * fxss0)
             else:
                 raw_bw = float(np.mean(np.abs(geo.fx2 - geo.fx1)))

--- a/tests/test_image_processing_sar_ifp.py
+++ b/tests/test_image_processing_sar_ifp.py
@@ -28,7 +28,7 @@ Created
 
 Modified
 --------
-2026-02-13
+2026-05-19
 """
 
 import pytest
@@ -483,6 +483,23 @@ class TestPolarGrid:
         grid = PolarGrid(geo, grid_mode='circumscribed')
         assert grid.rec_n_samples > 0
         assert grid.rec_n_pulses > 0
+
+    def test_fxss_fallback_uses_positive_values(self, geo):
+        geo.toa1 = None
+        geo.toa2 = None
+        geo.fxss[:] = 0.0
+        geo.fxss[1:] = 1.0e6
+
+        grid = PolarGrid(geo, grid_mode='inscribed')
+
+        kv_span = float(abs(grid.kv_bounds[1] - grid.kv_bounds[0]))
+        expected_scene_range = geo.c / (2.0 * 1.0e6)
+        expected_rec_n_samples = max(
+            1,
+            int(np.ceil(kv_span * expected_scene_range)),
+        )
+
+        assert grid.rec_n_samples == expected_rec_n_samples
 
     def test_invalid_mode_raises(self, geo):
         with pytest.raises(ValueError, match="grid_mode"):


### PR DESCRIPTION
- PolarGrid: size rec_n_samples/rec_n_pulses from TOA scene extent (c × mean(toa2-toa1)/2) and graze-angle azimuth heuristic instead of CPHD unambiguous range, reducing output from ~29 GB to ~5 GB
- CollectionGeometry: expose toa1/toa2 from PVP for PolarGrid use
- cphd_to_sicd_example: cast form_image output to complex64 (RDA returns complex128 due to np.exp upcast); update diagnostics
- sicd_writer: truncate CoreName to 74 chars so sarpy's 'SICD: ' prefix fits within the 80-char NITF FTITLE/IID2 limit

Much better for Capella CPHD files, but there are still some issues.