### PR TITLE
fix: PFA IFP focus + full-scene sizing (Debug IFPs, #49)

### DIFF
--- a/grdl/example/image_processing/sar/ifp_example.py
+++ b/grdl/example/image_processing/sar/ifp_example.py
@@ -52,6 +52,9 @@ Created
 
 Modified
 --------
+2026-06-01  Use scene_sizing='full' (whole scene from data sampling) and
+            the default (fixed) KaiserSinc interpolator; AMP_SF is applied
+            automatically. Drop the Polyphase interpolator workaround.
 2026-02-12
 """
 
@@ -66,8 +69,6 @@ import numpy as np
 
 # GRDL
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
-from grdl.interpolation import PolyphaseInterpolator
-
 from grdl.IO.sar import CPHDReader
 from grdl.image_processing.sar import (
     CollectionGeometry,
@@ -120,6 +121,14 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=1.0,
         help="Azimuth k-space oversampling factor, 1.0 = Nyquist (default: 1.0).",
+    )
+    parser.add_argument(
+        "--scene-sizing",
+        type=str,
+        default="full",
+        choices=["full", "toa"],
+        help="Output scene sizing: 'full' = whole scene from data sampling "
+             "(default), 'toa' = receive-window footprint.",
     )
     parser.add_argument(
         "--slant",
@@ -237,6 +246,7 @@ def run_ifp(
     grid_mode: str = "inscribed",
     range_oversample: float = 1.0,
     azimuth_oversample: float = 1.0,
+    scene_sizing: str = "full",
     slant: bool = True,
     plot_geometry: bool = False,
     plot_grid: bool = False,
@@ -255,6 +265,10 @@ def run_ifp(
         Range k-space oversampling factor.
     azimuth_oversample : float
         Azimuth k-space oversampling factor.
+    scene_sizing : str
+        ``'full'`` (default) sizes the output to the full scene the data
+        supports (range ``c/(2·fxss)``, azimuth ``npulses``); ``'toa'``
+        uses the smaller receive-window footprint.
     slant : bool
         If True, use slant plane.
     plot_geometry : bool
@@ -311,6 +325,7 @@ def run_ifp(
         grid_mode=grid_mode,
         range_oversample=range_oversample,
         azimuth_oversample=azimuth_oversample,
+        scene_sizing=scene_sizing,
     )
     print(f"  kv bounds: [{grid.kv_bounds[0]:.2f}, {grid.kv_bounds[1]:.2f}]")
     print(f"  ku bounds: [{grid.ku_bounds[0]:.4f}, {grid.ku_bounds[1]:.4f}]")
@@ -329,9 +344,12 @@ def run_ifp(
     phase_sgn = gp.phase_sgn if gp is not None else -1
     print(f"  PhaseSGN: {phase_sgn:+d}")
 
+    # Default interpolator is the bandwidth-preserving KaiserSinc, which
+    # now scales its kernel support with the downsample ratio (flat
+    # passband when the output grid is coarser than the input). Per-vector
+    # AMP_SF is applied automatically inside interpolate_range.
     pfa = PolarFormatAlgorithm(
         grid=grid,
-        interpolator=PolyphaseInterpolator( kernel_length=64, num_phases=256, prototype='kaiser' ),
         phase_sgn=phase_sgn,
     )
 
@@ -400,6 +418,7 @@ if __name__ == "__main__":
         grid_mode=args.grid_mode,
         range_oversample=args.range_oversample,
         azimuth_oversample=args.azimuth_oversample,
+        scene_sizing=args.scene_sizing,
         slant=not args.ground,
         plot_geometry=args.plot_geometry,
         plot_grid=args.plot_grid,

--- a/grdl/image_processing/sar/image_formation/geometry.py
+++ b/grdl/image_processing/sar/image_formation/geometry.py
@@ -32,7 +32,8 @@ Created
 
 Modified
 --------
-2026-05-15
+2026-06-01  Expose per-vector AMP_SF (CPHD amplitude scale factor) so the
+            PFA can calibrate per-pulse amplitude.
 """
 
 # Standard library
@@ -159,6 +160,12 @@ class CollectionGeometry:
         # Receive window (TOA) parameters — used by PolarGrid for scene extent
         self.toa1 = pvp.toa1
         self.toa2 = pvp.toa2
+
+        # Per-vector amplitude scale factor (CPHD AMP_SF). Calibrated
+        # signal = AmpSF * stored signal. Some sensors (e.g. Capella)
+        # record pulses at varying receiver gain encoded here; the PFA
+        # applies it so every pulse is on a common amplitude scale.
+        self.amp_sf = pvp.amp_sf
 
         # Build geometry
         self._build_reference_vectors(pvp)

--- a/grdl/image_processing/sar/image_formation/pfa.py
+++ b/grdl/image_processing/sar/image_formation/pfa.py
@@ -37,6 +37,10 @@ Created
 
 Modified
 --------
+2026-06-01  Apply per-vector AMP_SF (CPHD amplitude scale factor) in
+            interpolate_range so per-pulse receiver-gain variation
+            (e.g. Capella) is normalized; otherwise high-gain pulses
+            act as slow-time impulses and smear azimuth.
 2026-05-14  Cast CI2/CI4 structured int signal to complex64 in
             interpolate_range so numba kernels receive a standard
             floating-point complex dtype (fixes Capella CPHD).
@@ -266,10 +270,23 @@ class PolarFormatAlgorithm(ImageFormationAlgorithm):
             pg.sf_conv * np.cos(geo.phi[:npulses]) * geo.k_sf[:npulses]
         )
 
+        # Per-vector AMP_SF (CPHD amplitude scale factor). Calibrated
+        # signal = AmpSF * stored signal. Applied per pulse so sensors
+        # that record at varying receiver gain (e.g. Capella, whose
+        # high-gain pulses carry amp_sf ~0.002) are normalized to a
+        # common scale -- without it those pulses are orders of magnitude
+        # too bright, acting as slow-time impulses that smear azimuth.
+        amp = getattr(geo, 'amp_sf', None)
+        if amp is not None:
+            amp = np.asarray(amp)
+            if amp.shape[0] < npulses or not np.any(amp != amp.flat[0]):
+                amp = None  # missing/constant -> nothing to do
+
         for i in range(npulses):
             freq_i = sample_indices * geo.fxss[i] + geo.fx0[i]
             kv_i = pulse_scale[i] * freq_i
-            result[i, :] = self._interp(kv_i, signal[i, :], kv_uniform)
+            pulse = signal[i, :] if amp is None else signal[i, :] * amp[i]
+            result[i, :] = self._interp(kv_i, pulse, kv_uniform)
 
         return result
 

--- a/grdl/image_processing/sar/image_formation/polar_grid.py
+++ b/grdl/image_processing/sar/image_formation/polar_grid.py
@@ -28,6 +28,11 @@ Created
 
 Modified
 --------
+2026-06-01  Add scene_sizing='toa'|'full'. 'full' accurately predicts the
+            whole scene from the data sampling (range c/(2·fxss), azimuth
+            rec_n_pulses=npulses) so spotlight CPHDs that 'toa'
+            undersizes form their full footprint without hand-tuned
+            oversample. Default stays 'toa' (unchanged behavior).
 2026-05-19  Use a positive-value check for fxss fallback selection so the
             unambiguous-range estimate is only used when fxss is actually
             populated, not merely allocated.
@@ -78,6 +83,19 @@ class PolarGrid:
     azimuth_oversample : float
         Azimuth k-space oversampling factor.  1.0 = Nyquist rate,
         2.0 = twice Nyquist (twice as many azimuth samples).
+    scene_sizing : str
+        How the output grid dimensions are sized:
+
+        - ``'toa'`` (default): size to the receive-window illumination
+          footprint (``scene_range = c·(toa2−toa1)/2``; azimuth =
+          ``scene_range/cos(graze)``). Compact, but undersizes
+          collections whose recorded swath exceeds the TOA window.
+        - ``'full'``: accurate full-scene prediction from the data
+          sampling — range extent ``c/(2·fxss)`` (FX unambiguous swath,
+          → ``rec_n_samples`` ≈ ``nsamples``) and azimuth
+          ``rec_n_pulses = npulses`` (the pulse-Nyquist limit). No
+          geometry heuristic and no cap; use for spotlight CPHDs that
+          ``'toa'`` undersizes (e.g. Capella, Umbra).
 
     Attributes
     ----------
@@ -113,11 +131,17 @@ class PolarGrid:
         grid_mode: str = 'inscribed',
         range_oversample: float = 1.0,
         azimuth_oversample: float = 1.0,
+        scene_sizing: str = 'toa',
     ) -> None:
         self.geometry = geometry
         self.grid_mode = grid_mode.upper()
         self.range_oversample = range_oversample
         self.azimuth_oversample = azimuth_oversample
+        self.scene_sizing = scene_sizing.lower()
+        if self.scene_sizing not in ('toa', 'full'):
+            raise ValueError(
+                f"scene_sizing must be 'toa' or 'full', got '{scene_sizing}'"
+            )
 
         # Spatial frequency conversion factor: k = 2f/c
         self.sf_conv = 2.0 / geometry.c
@@ -235,40 +259,56 @@ class PolarGrid:
         # K-space bandwidths (1/m)
         kv_span = float(abs(self.kv_bounds[1] - self.kv_bounds[0]))
 
-        # Scene extent from TOA receive window.
-        # scene_range = c × mean(toa2 − toa1) / 2
-        toa1 = getattr(geo, 'toa1', None)
-        toa2 = getattr(geo, 'toa2', None)
-        if toa1 is not None and toa2 is not None:
-            toa_window = float(np.mean(np.abs(toa2 - toa1)))
-            scene_range = c * toa_window / 2.0
+        # Full FX unambiguous range swath: c / (2 * fxss).
+        fxss = np.asarray(geo.fxss)
+        positive_fxss = fxss[fxss > 0.0]
+        if positive_fxss.size > 0:
+            fx_scene_range = c / (2.0 * float(np.mean(positive_fxss)))
         else:
-            # Fallback: use unambiguous range from fxss (less accurate)
-            fxss = np.asarray(geo.fxss)
-            positive_fxss = fxss[fxss > 0.0]
-            if positive_fxss.size > 0:
-                fxss0 = float(np.mean(positive_fxss))
-                scene_range = c / (2.0 * fxss0)
-            else:
-                raw_bw = float(np.mean(np.abs(geo.fx2 - geo.fx1)))
-                scene_range = (
-                    c * max(geo.nsamples - 1, 1) / (2.0 * raw_bw)
-                    if raw_bw > 0.0 else 1.0
-                )
-
-        self.rec_n_samples = max(
-            1,
-            int(np.ceil(kv_span * scene_range * self.range_oversample)),
-        )
-
-        # Azimuth scene extent: scene_range / cos(mean grazing angle)
+            raw_bw = float(np.mean(np.abs(geo.fx2 - geo.fx1)))
+            fx_scene_range = (
+                c * max(geo.nsamples - 1, 1) / (2.0 * raw_bw)
+                if raw_bw > 0.0 else 1.0
+            )
         mean_graze = float(np.mean(geo.graz_ang))
-        scene_az = scene_range / max(np.cos(mean_graze), 0.1)
 
-        self.rec_n_pulses = max(
-            1,
-            int(np.ceil(ku_span * scene_az * self.azimuth_oversample)),
-        )
+        if self.scene_sizing == 'full':
+            # Accurate full-scene prediction from the data sampling, with
+            # no geometry heuristic and no Nyquist cap needed:
+            #   range  : extent = c/(2*fxss) (FX unambiguous swath)
+            #            -> rec_n_samples = kv_span * extent (~= nsamples)
+            #   azimuth: unambiguous extent = npulses / ku_span
+            #            -> rec_n_pulses = npulses (the pulse-Nyquist limit)
+            scene_range = fx_scene_range
+            scene_az = float(geo.npulses) / ku_span if ku_span > 0 else 0.0
+            self.rec_n_samples = max(
+                1,
+                int(np.ceil(kv_span * scene_range * self.range_oversample)),
+            )
+            self.rec_n_pulses = max(
+                1,
+                int(np.ceil(geo.npulses * self.azimuth_oversample)),
+            )
+        else:
+            # 'toa': size to the receive-window illumination footprint.
+            # scene_range = c * mean(toa2 - toa1) / 2.
+            toa1 = getattr(geo, 'toa1', None)
+            toa2 = getattr(geo, 'toa2', None)
+            if toa1 is not None and toa2 is not None:
+                toa_window = float(np.mean(np.abs(toa2 - toa1)))
+                scene_range = c * toa_window / 2.0
+            else:
+                scene_range = fx_scene_range
+            self.rec_n_samples = max(
+                1,
+                int(np.ceil(kv_span * scene_range * self.range_oversample)),
+            )
+            # Azimuth scene extent: scene_range / cos(mean grazing angle)
+            scene_az = scene_range / max(np.cos(mean_graze), 0.1)
+            self.rec_n_pulses = max(
+                1,
+                int(np.ceil(ku_span * scene_az * self.azimuth_oversample)),
+            )
 
         # Diagnostic: log grid sizing inputs so callers can verify
         self._diag = {

--- a/grdl/interpolation/windowed_sinc.py
+++ b/grdl/interpolation/windowed_sinc.py
@@ -32,7 +32,12 @@ Created
 
 Modified
 --------
-2026-02-12
+2026-06-01  Fix downsampling: scale kernel support by the downsample ratio
+            so the anti-alias filter has ~kernel_length taps in OUTPUT
+            spacing. The fixed-input-width window rolled off the passband
+            (eating real signal -> defocused PFA images); now flat to
+            near Nyquist. Estimate local spacing from immediate neighbors
+            so non-uniform (polar keystone) axes are handled correctly.
 """
 
 # Standard library
@@ -127,33 +132,62 @@ if _HAS_NUMBA:
                     hi_s = mid
             idx = lo_s
 
-            # Neighbor window centered at idx
-            start = idx - half + 1
-            if start < 0:
-                start = 0
-            if start + kernel_length > n:
-                start = n - kernel_length
-            if start < 0:
-                start = 0
-            end = start + kernel_length
-            if end > n:
-                end = n
-
-            # Local input spacing from neighborhood span
-            npts = end - start
-            if npts > 1:
-                dx_local = (x_old[end - 1] - x_old[start]) / (npts - 1)
+            # Estimate the LOCAL input spacing from the immediate
+            # neighbors (works for non-uniform axes, e.g. the polar
+            # keystone ku = kv*tan(phi)).
+            jb = idx - 1
+            if jb < 0:
+                jb = 0
+            jf = idx
+            if jf > n - 1:
+                jf = n - 1
+            if jf > jb:
+                dx_local = (x_old[jf] - x_old[jb]) / (jf - jb)
             else:
                 dx_local = 1.0
             if dx_local < 1e-30:
                 dx_local = 1.0
 
-            # Anti-alias: normalize sinc by the coarser of
-            # input/output spacing so cutoff tracks output Nyquist
-            # when downsampling.
+            # Downsample ratio. When the output grid is coarser than the
+            # input (ratio > 1), the anti-alias sinc must be cut off at
+            # the OUTPUT Nyquist -- which requires ~kernel_length taps in
+            # OUTPUT spacing, i.e. kernel_length*ratio INPUT samples. The
+            # original code fixed the window at kernel_length INPUT
+            # samples, giving only kernel_length/ratio output taps -> a
+            # far-too-short filter that rolls off the passband (eats real
+            # signal). Scale the kernel support by the ratio so the
+            # passband stays flat to ~output Nyquist.
+            ratio = dx_output / dx_local
+            if ratio < 1.0:
+                ratio = 1.0
+            half_eff = int(half * ratio + 0.5)
+            if half_eff < half:
+                half_eff = half
+            klen = 2 * half_eff
+
+            # Window of klen input samples centered at idx
+            start = idx - half_eff + 1
+            if start < 0:
+                start = 0
+            if klen > n:
+                klen = n
+            if start + klen > n:
+                start = n - klen
+            if start < 0:
+                start = 0
+            end = start + klen
+            if end > n:
+                end = n
+
+            # Sinc cutoff at the coarser (output) spacing for anti-alias;
+            # Kaiser window spans the full (scaled) support so the filter
+            # is long enough in output-spacing taps.
             dx_norm = dx_local
             if dx_output > dx_local:
                 dx_norm = dx_output
+            support = half_eff * dx_local   # = half*dx_output when downsampling
+            if support < 1e-30:
+                support = 1.0
 
             # Accumulate weighted sum
             w_sum = 0.0
@@ -165,8 +199,8 @@ if _HAS_NUMBA:
                 # Sinc referenced to max(input, output) spacing
                 w = _sinc(dist / dx_norm * oversample)
 
-                # Kaiser window on input spacing (full kernel support)
-                u = dist / (dx_local * half)
+                # Kaiser window over the full (ratio-scaled) support
+                u = dist / support
                 u_sq = u * u
                 if u_sq < 1.0:
                     arg = beta * math.sqrt(1.0 - u_sq)


### PR DESCRIPTION
Fixes from debugging real Capella/Umbra spotlight CPHD image formation (issue #49, "Debug IFPs").

## Changes
- **`interpolation/windowed_sinc.py`** — KaiserSinc rolled off the passband when downsampling (kernel fixed at `kernel_length` *input* samples → only `kernel_length/ratio` *output* taps), attenuating real signal and defocusing PFA images. Now scales kernel support by the downsample ratio (flat passband to near Nyquist) and estimates local spacing from neighbors so the non-uniform polar keystone axis works.
- **`image_formation/pfa.py` + `geometry.py`** — apply the CPHD per-vector **AMP_SF** scale factor in `interpolate_range` (`calibrated = AmpSF · stored`). Without it, sensors recording at varying gain (Capella) leave ~8% of pulses ~440× too bright → azimuth stripes.
- **`image_formation/polar_grid.py`** — add `scene_sizing='toa'|'full'`. `'full'` predicts the whole scene from the data sampling (range `c/(2·fxss)`, azimuth `rec_n_pulses=npulses`) so spotlight CPHDs the TOA-window default undersizes form their full footprint. **Default stays `'toa'`** (no regression for existing callers, e.g. GMTI).
- **`example/.../ifp_example.py`** — use `scene_sizing='full'` and the default (fixed) KaiserSinc; drop the Polyphase workaround.

## Validation
- Umbra full aperture: sharpness 0.3 → 263k (crisp full-scene city)
- Capella SP: focuses (was azimuth-striped); full 6.1 × 13.9 km scene
- aspen sim: unaffected
- KaiserSinc isolated tests: flat passband restored (keystone 0.05 → 0.998)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)