### PR TITLE
fix: S1 L0 POE auto-download uses ASF (pass scene_name)

### DIFF
--- a/grdl/IO/sar/sentinel1_l0/reader.py
+++ b/grdl/IO/sar/sentinel1_l0/reader.py
@@ -49,7 +49,8 @@ Created
 
 Modified
 --------
-2026-06-01
+2026-06-01  Pass scene_name to POE auto-download so the ASF orbit API is
+            used (the ESA step.esa.int fallback 404s for recent dates).
 """
 
 # Standard library
@@ -864,6 +865,13 @@ class Sentinel1L0Reader(ImageReader):
         )
         mission = f"S1{mission_letter}"
 
+        # Scene name (SAFE dir without the .SAFE suffix) enables the ASF
+        # orbit API in download_poe. Without it, download falls straight
+        # to the ESA step.esa.int archive, which 404s for recent dates.
+        scene_name = self.filepath.name
+        if scene_name.upper().endswith(".SAFE"):
+            scene_name = scene_name[:-5]
+
         # Candidate search locations in priority order.
         search_dirs = []
         if self._config.poe_directory:
@@ -879,6 +887,7 @@ class Sentinel1L0Reader(ImageReader):
             try:
                 found = self._orbit_loader.find_and_load_poe(
                     directory, start_time, mission,
+                    scene_name=scene_name,
                 )
                 if found:
                     logger.info(


### PR DESCRIPTION
`Sentinel1L0Reader` called `find_and_load_poe(directory, time, mission)` **without `scene_name`**, so `download_poe` skipped the ASF orbit API (guarded by `if scene_name:`) and fell straight to the ESA `step.esa.int` archive, which **404s for recent acquisitions**.

Fix: derive `scene_name` from the SAFE directory name and pass it through, so the reliable **ASF** orbit API is used (ESA remains a fallback).

- Non-fatal before (reader falls back to onboard ephemeris), but the precise POE orbit is now fetched.
- Verified: ASF returns the covering POE for a 2025-11 scene (4.7 MB, validity brackets the acquisition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)